### PR TITLE
feat: Add student profile completion feature (US-16, US-17, US-18, US…

### DIFF
--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -21,6 +21,15 @@ model User {
   createdAt                  DateTime  @default(now()) @map("created_at")
   updatedAt                  DateTime  @updatedAt @map("updated_at")
 
+  // Student Profile Fields (US-16, US-17, US-18)
+  dateOfBirth        DateTime?     @map("date_of_birth")
+  phoneNumber        String?       @map("phone_number")
+  aboutMe            String?       @map("about_me") @db.Text
+  spanishLevel       SpanishLevel? @map("spanish_level")
+  preferredClassTypes String?      @map("preferred_class_types") // JSON array of ClassType values
+  learningGoals      String?       @map("learning_goals") @db.Text
+  availabilityNotes  String?       @map("availability_notes") @db.Text
+
   slots                    AvailabilitySlot[]
   bookings                 Booking[]
   notesWritten             StudentNote[]      @relation("NotesWritten")
@@ -167,6 +176,16 @@ enum BookingStatus {
   CANCELLED_BY_PROFESSOR
   COMPLETED
   NO_SHOW
+}
+
+// Spanish proficiency levels (CEFR-aligned)
+enum SpanishLevel {
+  BEGINNER        // A1
+  ELEMENTARY      // A2
+  INTERMEDIATE    // B1
+  UPPER_INTERMEDIATE // B2
+  ADVANCED        // C1
+  NATIVE          // C2/Native
 }
 
 model EmailLog {

--- a/packages/backend/src/routes/professor.ts
+++ b/packages/backend/src/routes/professor.ts
@@ -1030,7 +1030,7 @@ router.get('/students', validateQuery(paginationSchema), async (req, res, next) 
   }
 });
 
-// GET /api/professor/students/:id
+// GET /api/professor/students/:id - includes student profile (US-19)
 router.get('/students/:id', async (req, res, next) => {
   try {
     const student = await prisma.user.findFirst({
@@ -1045,6 +1045,14 @@ router.get('/students/:id', async (req, res, next) => {
         lastName: true,
         timezone: true,
         createdAt: true,
+        // Student profile fields (US-19)
+        dateOfBirth: true,
+        phoneNumber: true,
+        aboutMe: true,
+        spanishLevel: true,
+        preferredClassTypes: true,
+        learningGoals: true,
+        availabilityNotes: true,
         bookings: {
           include: {
             slot: {
@@ -1075,10 +1083,18 @@ router.get('/students/:id', async (req, res, next) => {
       orderBy: { createdAt: 'desc' },
     });
 
+    // Parse preferredClassTypes from JSON string to array
+    const profile = {
+      ...student,
+      preferredClassTypes: student.preferredClassTypes
+        ? JSON.parse(student.preferredClassTypes)
+        : null,
+    };
+
     res.json({
       success: true,
       data: {
-        ...student,
+        ...profile,
         notes,
       },
     });

--- a/packages/backend/src/services/booking.ts
+++ b/packages/backend/src/services/booking.ts
@@ -169,14 +169,16 @@ export async function bookSlot(
   }).catch((err: unknown) => console.error('Failed to create booked session calendar event:', err));
 
   // Send emails (don't await, let them run in background)
+  // Cast slot to fix Prisma enum vs shared enum type mismatch
+  const slotForEmail = slot as unknown as import('@spanish-class/shared').AvailabilitySlot;
   Promise.all([
     sendBookingConfirmationToStudent({
-      slot,
+      slot: slotForEmail,
       professor: slot.professor,
       student,
     }),
     sendBookingNotificationToProfessor({
-      slot,
+      slot: slotForEmail,
       professor: slot.professor,
       student,
     }),
@@ -300,9 +302,11 @@ export async function cancelBooking(
   }
 
   // Send cancellation emails
+  // Cast slot to fix Prisma enum vs shared enum type mismatch
+  const cancelSlotForEmail = booking.slot as unknown as import('@spanish-class/shared').AvailabilitySlot;
   Promise.all([
     sendCancellationToStudent({
-      slot: booking.slot,
+      slot: cancelSlotForEmail,
       professor: booking.slot.professor,
       student: booking.student,
       reason,
@@ -310,7 +314,7 @@ export async function cancelBooking(
     }),
     cancelledBy === 'student'
       ? sendCancellationToProfessor({
-          slot: booking.slot,
+          slot: cancelSlotForEmail,
           professor: booking.slot.professor,
           student: booking.student,
           reason,

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { EmailLogsPage } from '@/pages/admin/EmailLogsPage';
 import { StudentDashboard } from '@/pages/student/StudentDashboard';
 import { BookPage } from '@/pages/student/BookPage';
 import { BookingsPage } from '@/pages/student/BookingsPage';
+import { StudentProfilePage } from '@/pages/student/StudentProfilePage';
 
 // Shared Pages
 import { SettingsPage } from '@/pages/shared/SettingsPage';
@@ -157,6 +158,7 @@ function AppRoutes() {
         <Route index element={<StudentDashboard />} />
         <Route path="book" element={<BookPage />} />
         <Route path="bookings" element={<BookingsPage />} />
+        <Route path="profile" element={<StudentProfilePage />} />
         <Route path="settings" element={<SettingsPage />} />
       </Route>
 

--- a/packages/frontend/src/components/layout/DashboardLayout.tsx
+++ b/packages/frontend/src/components/layout/DashboardLayout.tsx
@@ -13,6 +13,7 @@ import {
   ChevronLeft,
   Plus,
   Mail,
+  UserCircle,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -39,6 +40,7 @@ const studentNavItems: NavItem[] = [
   { href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
   { href: '/dashboard/book', label: 'Book Class', icon: Calendar },
   { href: '/dashboard/bookings', label: 'My Bookings', icon: BookOpen },
+  { href: '/dashboard/profile', label: 'My Profile', icon: UserCircle },
   { href: '/dashboard/settings', label: 'Settings', icon: Settings },
 ];
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -18,6 +18,9 @@ import type {
   RecurringPattern,
   CreateRecurringPatternInput,
   ProfessorBookStudentInput,
+  StudentProfile,
+  ProfileCompletion,
+  UpdateStudentProfileInput,
 } from '@spanish-class/shared';
 
 const api = axios.create({
@@ -255,6 +258,17 @@ export const studentApi = {
 
   cancelBooking: async (id: string, reason?: string): Promise<void> => {
     await api.post(`/student/bookings/${id}/cancel`, { reason });
+  },
+
+  // Profile (US-16, US-17, US-18)
+  getProfile: async (): Promise<{ profile: StudentProfile; completion: ProfileCompletion }> => {
+    const res = await api.get('/student/profile');
+    return res.data.data;
+  },
+
+  updateProfile: async (data: UpdateStudentProfileInput): Promise<{ profile: StudentProfile; completion: ProfileCompletion }> => {
+    const res = await api.put('/student/profile', data);
+    return res.data.data;
   },
 };
 

--- a/packages/frontend/src/pages/admin/StudentDetailPage.tsx
+++ b/packages/frontend/src/pages/admin/StudentDetailPage.tsx
@@ -2,7 +2,20 @@ import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
-import { ArrowLeft, Calendar, Mail, Globe, Plus, Edit, Trash2, Clock } from 'lucide-react';
+import {
+  ArrowLeft,
+  Calendar,
+  Mail,
+  Globe,
+  Plus,
+  Edit,
+  Trash2,
+  Clock,
+  Phone,
+  BookOpen,
+  Target,
+  MessageSquare,
+} from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -166,11 +179,121 @@ export function StudentDetailPage() {
       </Card>
 
       {/* Tabs */}
-      <Tabs defaultValue="bookings">
+      <Tabs defaultValue="profile">
         <TabsList>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
           <TabsTrigger value="bookings">Bookings</TabsTrigger>
           <TabsTrigger value="notes">Notes ({student.notes?.length || 0})</TabsTrigger>
         </TabsList>
+
+        {/* Profile Tab (US-19) */}
+        <TabsContent value="profile" className="mt-6 space-y-4">
+          <div className="grid md:grid-cols-2 gap-4">
+            {/* Personal Details */}
+            <Card>
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-navy-800 mb-4 flex items-center gap-2">
+                  <MessageSquare className="h-5 w-5" />
+                  Personal Details
+                </h3>
+                <div className="space-y-3">
+                  {student.dateOfBirth && (
+                    <div className="flex items-center gap-3">
+                      <Calendar className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm">
+                        <span className="text-muted-foreground">DOB: </span>
+                        {formatDate(student.dateOfBirth)}
+                      </span>
+                    </div>
+                  )}
+                  {student.phoneNumber && (
+                    <div className="flex items-center gap-3">
+                      <Phone className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-sm">{student.phoneNumber}</span>
+                    </div>
+                  )}
+                  {student.aboutMe ? (
+                    <div className="mt-4">
+                      <p className="text-sm text-muted-foreground mb-1">About</p>
+                      <p className="text-sm bg-gray-50 p-3 rounded-lg">{student.aboutMe}</p>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground italic">
+                      No personal details provided yet
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Learning Preferences */}
+            <Card>
+              <CardContent className="p-6">
+                <h3 className="font-semibold text-navy-800 mb-4 flex items-center gap-2">
+                  <BookOpen className="h-5 w-5" />
+                  Learning Preferences
+                </h3>
+                <div className="space-y-3">
+                  {student.spanishLevel && (
+                    <div>
+                      <p className="text-sm text-muted-foreground">Spanish Level</p>
+                      <Badge variant="outline" className="mt-1">
+                        {student.spanishLevel.replace(/_/g, ' ')}
+                      </Badge>
+                    </div>
+                  )}
+                  {student.preferredClassTypes && student.preferredClassTypes.length > 0 && (
+                    <div>
+                      <p className="text-sm text-muted-foreground mb-1">Preferred Class Types</p>
+                      <div className="flex flex-wrap gap-1">
+                        {student.preferredClassTypes.map((type: string) => (
+                          <Badge key={type} variant="secondary" className="text-xs">
+                            {type.replace(/_/g, ' ')}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {!student.spanishLevel && !student.preferredClassTypes?.length && (
+                    <p className="text-sm text-muted-foreground italic">
+                      No learning preferences set yet
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Learning Goals */}
+            {student.learningGoals && (
+              <Card>
+                <CardContent className="p-6">
+                  <h3 className="font-semibold text-navy-800 mb-4 flex items-center gap-2">
+                    <Target className="h-5 w-5" />
+                    Learning Goals
+                  </h3>
+                  <p className="text-sm bg-gray-50 p-3 rounded-lg whitespace-pre-wrap">
+                    {student.learningGoals}
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Availability Notes */}
+            {student.availabilityNotes && (
+              <Card>
+                <CardContent className="p-6">
+                  <h3 className="font-semibold text-navy-800 mb-4 flex items-center gap-2">
+                    <Clock className="h-5 w-5" />
+                    Availability Notes
+                  </h3>
+                  <p className="text-sm bg-gray-50 p-3 rounded-lg whitespace-pre-wrap">
+                    {student.availabilityNotes}
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+        </TabsContent>
 
         <TabsContent value="bookings" className="mt-6 space-y-4">
           {student.bookings.length > 0 ? (

--- a/packages/frontend/src/pages/student/StudentProfilePage.tsx
+++ b/packages/frontend/src/pages/student/StudentProfilePage.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import {
+  User,
+  Calendar,
+  Phone,
+  BookOpen,
+  Target,
+  Clock,
+  CheckCircle2,
+  Circle,
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { studentApi } from '@/lib/api';
+import {
+  SpanishLevel,
+  ClassType,
+} from '@spanish-class/shared';
+import type {
+  ProfileCompletion,
+} from '@spanish-class/shared';
+
+const spanishLevels: { value: SpanishLevel; label: string; description: string }[] = [
+  { value: SpanishLevel.BEGINNER, label: 'Beginner (A1)', description: 'Just starting out' },
+  { value: SpanishLevel.ELEMENTARY, label: 'Elementary (A2)', description: 'Basic phrases and expressions' },
+  { value: SpanishLevel.INTERMEDIATE, label: 'Intermediate (B1)', description: 'Can handle most situations' },
+  { value: SpanishLevel.UPPER_INTERMEDIATE, label: 'Upper Intermediate (B2)', description: 'Fluent in familiar topics' },
+  { value: SpanishLevel.ADVANCED, label: 'Advanced (C1)', description: 'Express ideas fluently' },
+  { value: SpanishLevel.NATIVE, label: 'Native (C2)', description: 'Native or near-native' },
+];
+
+const classTypes: { value: ClassType; label: string }[] = [
+  { value: ClassType.PRIVATE_LESSONS, label: 'Private Lessons' },
+  { value: ClassType.GROUP_CLASSES, label: 'Group Classes' },
+  { value: ClassType.CONVERSATION_PRACTICE, label: 'Conversation Practice' },
+  { value: ClassType.EXAM_PREPARATION, label: 'Exam Preparation' },
+  { value: ClassType.BUSINESS_SPANISH, label: 'Business Spanish' },
+  { value: ClassType.GRAMMAR_FOCUS, label: 'Grammar Focus' },
+  { value: ClassType.PRONUNCIATION, label: 'Pronunciation' },
+  { value: ClassType.WRITING_SKILLS, label: 'Writing Skills' },
+];
+
+interface ProfileFormData {
+  dateOfBirth: string;
+  phoneNumber: string;
+  aboutMe: string;
+  spanishLevel: SpanishLevel | '';
+  preferredClassTypes: ClassType[];
+  learningGoals: string;
+  availabilityNotes: string;
+}
+
+export function StudentProfilePage() {
+  const [completion, setCompletion] = useState<ProfileCompletion | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<ProfileFormData>({
+    defaultValues: {
+      dateOfBirth: '',
+      phoneNumber: '',
+      aboutMe: '',
+      spanishLevel: '',
+      preferredClassTypes: [],
+      learningGoals: '',
+      availabilityNotes: '',
+    },
+  });
+
+  useEffect(() => {
+    loadProfile();
+  }, []);
+
+  const loadProfile = async () => {
+    try {
+      setIsLoading(true);
+      const data = await studentApi.getProfile();
+      setCompletion(data.completion);
+
+      // Reset form with loaded data
+      reset({
+        dateOfBirth: data.profile.dateOfBirth
+          ? new Date(data.profile.dateOfBirth).toISOString().split('T')[0]
+          : '',
+        phoneNumber: data.profile.phoneNumber || '',
+        aboutMe: data.profile.aboutMe || '',
+        spanishLevel: data.profile.spanishLevel || '',
+        preferredClassTypes: data.profile.preferredClassTypes || [],
+        learningGoals: data.profile.learningGoals || '',
+        availabilityNotes: data.profile.availabilityNotes || '',
+      });
+    } catch (error: any) {
+      toast.error(error.response?.data?.error || 'Failed to load profile');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const onSubmit = async (data: ProfileFormData) => {
+    try {
+      const updateData = {
+        dateOfBirth: data.dateOfBirth || null,
+        phoneNumber: data.phoneNumber || null,
+        aboutMe: data.aboutMe || null,
+        spanishLevel: data.spanishLevel || null,
+        preferredClassTypes: data.preferredClassTypes.length > 0 ? data.preferredClassTypes : null,
+        learningGoals: data.learningGoals || null,
+        availabilityNotes: data.availabilityNotes || null,
+      };
+
+      const result = await studentApi.updateProfile(updateData);
+      setCompletion(result.completion);
+      toast.success('Profile updated successfully');
+    } catch (error: any) {
+      toast.error(error.response?.data?.error || 'Failed to update profile');
+    }
+  };
+
+  const toggleClassType = (classType: ClassType, currentTypes: ClassType[]) => {
+    if (currentTypes.includes(classType)) {
+      return currentTypes.filter((t) => t !== classType);
+    }
+    return [...currentTypes, classType];
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gold-500" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-display font-bold text-navy-800">My Profile</h1>
+        <p className="text-muted-foreground">
+          Complete your profile to help your professor personalize your learning experience
+        </p>
+      </div>
+
+      {/* Profile Completion Indicator */}
+      {completion && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="font-semibold text-navy-800">Profile Completion</h3>
+                <p className="text-sm text-muted-foreground">
+                  {completion.completedCount} of {completion.totalCount} fields completed
+                </p>
+              </div>
+              <div className="text-3xl font-bold text-gold-600">{completion.percentage}%</div>
+            </div>
+
+            {/* Progress Bar */}
+            <div className="w-full bg-gray-200 rounded-full h-3 mb-4">
+              <div
+                className="bg-gradient-to-r from-gold-400 to-gold-600 h-3 rounded-full transition-all duration-500"
+                style={{ width: `${completion.percentage}%` }}
+              />
+            </div>
+
+            {/* Completion Items */}
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {completion.items.map((item) => (
+                <div
+                  key={item.field}
+                  className={`flex items-center gap-2 text-sm p-2 rounded ${
+                    item.completed ? 'text-green-700 bg-green-50' : 'text-gray-500 bg-gray-50'
+                  }`}
+                >
+                  {item.completed ? (
+                    <CheckCircle2 className="h-4 w-4 text-green-600" />
+                  ) : (
+                    <Circle className="h-4 w-4 text-gray-400" />
+                  )}
+                  <span>{item.label}</span>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        {/* Personal Details (US-18) */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <User className="h-5 w-5" />
+              Personal Details
+            </CardTitle>
+            <CardDescription>Tell us a bit about yourself</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid sm:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="dateOfBirth" className="flex items-center gap-2">
+                  <Calendar className="h-4 w-4" />
+                  Date of Birth
+                </Label>
+                <Input
+                  id="dateOfBirth"
+                  type="date"
+                  {...register('dateOfBirth')}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="phoneNumber" className="flex items-center gap-2">
+                  <Phone className="h-4 w-4" />
+                  Phone Number
+                </Label>
+                <Input
+                  id="phoneNumber"
+                  type="tel"
+                  placeholder="+1 (555) 000-0000"
+                  {...register('phoneNumber')}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="aboutMe">About Me</Label>
+              <Textarea
+                id="aboutMe"
+                placeholder="Tell us a bit about yourself, your background, and why you're learning Spanish..."
+                className="min-h-[100px]"
+                {...register('aboutMe')}
+              />
+              <p className="text-xs text-muted-foreground">
+                This helps your professor understand your background and personalize lessons
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Learning Preferences (US-17) */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <BookOpen className="h-5 w-5" />
+              Learning Preferences
+            </CardTitle>
+            <CardDescription>Help us tailor your learning experience</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>Spanish Level</Label>
+              <Controller
+                name="spanishLevel"
+                control={control}
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select your current level" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {spanishLevels.map((level) => (
+                        <SelectItem key={level.value} value={level.value}>
+                          <div>
+                            <span className="font-medium">{level.label}</span>
+                            <span className="text-muted-foreground ml-2">- {level.description}</span>
+                          </div>
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label>Preferred Class Types</Label>
+              <p className="text-xs text-muted-foreground mb-2">
+                Select the types of classes you're interested in
+              </p>
+              <Controller
+                name="preferredClassTypes"
+                control={control}
+                render={({ field }) => (
+                  <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+                    {classTypes.map((classType) => {
+                      const isSelected = field.value.includes(classType.value);
+                      return (
+                        <button
+                          key={classType.value}
+                          type="button"
+                          onClick={() => field.onChange(toggleClassType(classType.value, field.value))}
+                          className={`p-3 text-sm rounded-lg border transition-all ${
+                            isSelected
+                              ? 'bg-gold-50 border-gold-500 text-gold-800'
+                              : 'bg-white border-gray-200 text-gray-700 hover:border-gray-300'
+                          }`}
+                        >
+                          {classType.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="learningGoals" className="flex items-center gap-2">
+                <Target className="h-4 w-4" />
+                Learning Goals
+              </Label>
+              <Textarea
+                id="learningGoals"
+                placeholder="What do you hope to achieve? (e.g., prepare for DELE exam, business communication, travel, etc.)"
+                className="min-h-[100px]"
+                {...register('learningGoals')}
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="availabilityNotes" className="flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                Availability Notes
+              </Label>
+              <Textarea
+                id="availabilityNotes"
+                placeholder="Let us know your preferred times or any scheduling constraints..."
+                className="min-h-[80px]"
+                {...register('availabilityNotes')}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Save Button */}
+        <div className="flex justify-end">
+          <Button type="submit" size="lg" isLoading={isSubmitting}>
+            Save Profile
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -145,11 +145,46 @@ export const updateNoteSchema = z.object({
   content: z.string().min(1, 'Note content is required').max(5000),
 });
 
+// Student Profile Enums
+export const spanishLevelEnum = z.enum([
+  'BEGINNER',
+  'ELEMENTARY',
+  'INTERMEDIATE',
+  'UPPER_INTERMEDIATE',
+  'ADVANCED',
+  'NATIVE',
+]);
+
+export const classTypeEnum = z.enum([
+  'PRIVATE_LESSONS',
+  'GROUP_CLASSES',
+  'CONVERSATION_PRACTICE',
+  'EXAM_PREPARATION',
+  'BUSINESS_SPANISH',
+  'GRAMMAR_FOCUS',
+  'PRONUNCIATION',
+  'WRITING_SKILLS',
+]);
+
 // User Schemas
 export const updateUserSchema = z.object({
   firstName: z.string().min(1).max(50).optional(),
   lastName: z.string().min(1).max(50).optional(),
   timezone: z.string().optional(),
+});
+
+// Student Profile Schema (US-16, US-17, US-18)
+export const updateStudentProfileSchema = z.object({
+  // Personal details (US-18)
+  dateOfBirth: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (YYYY-MM-DD)').optional().nullable(),
+  phoneNumber: z.string().max(20).optional().nullable(),
+  aboutMe: z.string().max(1000).optional().nullable(),
+
+  // Learning preferences (US-17)
+  spanishLevel: spanishLevelEnum.optional().nullable(),
+  preferredClassTypes: z.array(classTypeEnum).optional().nullable(),
+  learningGoals: z.string().max(2000).optional().nullable(),
+  availabilityNotes: z.string().max(1000).optional().nullable(),
 });
 
 export const changePasswordSchema = z
@@ -204,3 +239,4 @@ export type SlotsQueryInput = z.infer<typeof slotsQuerySchema>;
 export type BookingsQueryInput = z.infer<typeof bookingsQuerySchema>;
 export type CreateRecurringPatternInput = z.infer<typeof createRecurringPatternSchema>;
 export type ProfessorBookStudentInput = z.infer<typeof professorBookStudentSchema>;
+export type UpdateStudentProfileInput = z.infer<typeof updateStudentProfileSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,3 +1,25 @@
+// Spanish proficiency levels (CEFR-aligned)
+export enum SpanishLevel {
+  BEGINNER = 'BEGINNER',           // A1
+  ELEMENTARY = 'ELEMENTARY',       // A2
+  INTERMEDIATE = 'INTERMEDIATE',   // B1
+  UPPER_INTERMEDIATE = 'UPPER_INTERMEDIATE', // B2
+  ADVANCED = 'ADVANCED',           // C1
+  NATIVE = 'NATIVE',               // C2/Native
+}
+
+// Class type preferences for students
+export enum ClassType {
+  PRIVATE_LESSONS = 'PRIVATE_LESSONS',
+  GROUP_CLASSES = 'GROUP_CLASSES',
+  CONVERSATION_PRACTICE = 'CONVERSATION_PRACTICE',
+  EXAM_PREPARATION = 'EXAM_PREPARATION',
+  BUSINESS_SPANISH = 'BUSINESS_SPANISH',
+  GRAMMAR_FOCUS = 'GRAMMAR_FOCUS',
+  PRONUNCIATION = 'PRONUNCIATION',
+  WRITING_SKILLS = 'WRITING_SKILLS',
+}
+
 // User Types
 export interface User {
   id: string;
@@ -8,6 +30,14 @@ export interface User {
   timezone: string;
   createdAt: Date;
   updatedAt: Date;
+  // Student Profile Fields
+  dateOfBirth?: Date | null;
+  phoneNumber?: string | null;
+  aboutMe?: string | null;
+  spanishLevel?: SpanishLevel | null;
+  preferredClassTypes?: ClassType[] | null;
+  learningGoals?: string | null;
+  availabilityNotes?: string | null;
 }
 
 export interface UserWithPassword extends User {
@@ -15,6 +45,39 @@ export interface UserWithPassword extends User {
 }
 
 export type UserPublic = Omit<User, 'passwordHash'>;
+
+// Student Profile Types
+export interface StudentProfile {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  timezone: string;
+  dateOfBirth?: Date | null;
+  phoneNumber?: string | null;
+  aboutMe?: string | null;
+  spanishLevel?: SpanishLevel | null;
+  preferredClassTypes?: ClassType[] | null;
+  learningGoals?: string | null;
+  availabilityNotes?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Profile completion tracking
+export interface ProfileCompletionItem {
+  field: string;
+  label: string;
+  completed: boolean;
+  weight: number; // Percentage weight for this field
+}
+
+export interface ProfileCompletion {
+  percentage: number;
+  items: ProfileCompletionItem[];
+  completedCount: number;
+  totalCount: number;
+}
 
 // Slot Types
 export enum SlotType {


### PR DESCRIPTION
…-19)

- Add Prisma schema fields for student profiles: dateOfBirth, phoneNumber, aboutMe, spanishLevel, preferredClassTypes, learningGoals, availabilityNotes
- Add SpanishLevel enum to Prisma and shared types
- Add ClassType enum for class preferences
- Create student profile API endpoints (GET/PUT /api/student/profile)
- Add profile completion calculation with weighted fields
- Create StudentProfilePage with completion indicator
- Update professor StudentDetailPage to show student profile info
- Add navigation link to student profile in sidebar

https://claude.ai/code/session_01YCk1DRMgbEqYY13hHWdyN3