### PR TITLE
feat(auth): password reset + email verification (P0)

### DIFF
--- a/packages/backend/prisma/migrations/20260625120000_p0_password_reset_email_verification/migration.sql
+++ b/packages/backend/prisma/migrations/20260625120000_p0_password_reset_email_verification/migration.sql
@@ -1,0 +1,30 @@
+-- AlterTable
+ALTER TABLE `users` ADD COLUMN `email_verification_expires_at` DATETIME(3) NULL,
+    ADD COLUMN `email_verification_token` VARCHAR(128) NULL,
+    ADD COLUMN `is_email_verified` BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE `password_reset_tokens` (
+    `id` VARCHAR(191) NOT NULL,
+    `user_id` VARCHAR(191) NOT NULL,
+    `token_hash` VARCHAR(64) NOT NULL,
+    `expires_at` DATETIME(3) NOT NULL,
+    `used_at` DATETIME(3) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `password_reset_tokens_token_hash_key`(`token_hash`),
+    INDEX `password_reset_tokens_user_id_idx`(`user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE UNIQUE INDEX `users_email_verification_token_key` ON `users`(`email_verification_token`);
+
+-- AddForeignKey
+ALTER TABLE `password_reset_tokens` ADD CONSTRAINT `password_reset_tokens_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+
+-- Backfill: all existing users are considered verified so they aren't locked out
+-- after this migration ships. Only NEW users registered after this migration
+-- will go through the email verification flow.
+UPDATE `users` SET `is_email_verified` = true WHERE `created_at` < NOW();

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -43,6 +43,12 @@ model User {
   ratingsReceived          Rating[]           @relation("RatingsReceived")
   twoFactor                UserTwoFactor?
   auditLogsActed           AdminAuditLog[]    @relation("AuditLogsActed")
+  passwordResetTokens      PasswordResetToken[]
+
+  // Email verification
+  isEmailVerified            Boolean   @default(false) @map("is_email_verified")
+  emailVerificationToken     String?   @unique @map("email_verification_token") @db.VarChar(128)
+  emailVerificationExpiresAt DateTime? @map("email_verification_expires_at")
 
   @@map("users")
 }
@@ -397,4 +403,18 @@ model AdminAuditLog {
   @@index([actorId, createdAt])
   @@index([createdAt])
   @@map("admin_audit_logs")
+}
+
+model PasswordResetToken {
+  id        String    @id @default(cuid())
+  userId    String    @map("user_id")
+  tokenHash String    @unique @map("token_hash") @db.VarChar(64)
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("password_reset_tokens")
 }

--- a/packages/backend/src/routes/auth.ts
+++ b/packages/backend/src/routes/auth.ts
@@ -12,9 +12,17 @@ import {
   updateUserSchema,
   verifyTotpSchema,
   verifyTotpWithRecoverySchema,
+  forgotPasswordSchema,
+  resetPasswordSchema,
+  verifyEmailSchema,
+  resendVerificationSchema,
 } from "@spanish-class/shared";
 import { AppError } from "../middleware/error.js";
-import { sendVerificationEmail } from "../services/email.js";
+import { sendVerificationEmail, sendPasswordResetEmail } from "../services/email.js";
+import {
+  createPasswordResetToken,
+  validateAndConsumePasswordResetToken,
+} from "../services/passwordReset.js";
 import {
   generateTotpSetup,
   verifyAndEnableTotp,
@@ -28,30 +36,23 @@ const VERIFICATION_TOKEN_EXPIRY_HOURS = 24;
 
 const router: RouterType = Router();
 
-// POST /api/auth/register
+// ── Register ──────────────────────────────────────────────────────────────────
+
 router.post("/register", authLimiter, validate(registerSchema), async (req, res, next) => {
   try {
     const { email, password, firstName, lastName, timezone } = req.body;
 
-    // Check if user already exists
-    const existingUser = await prisma.user.findUnique({
-      where: { email },
-    });
-
+    const existingUser = await prisma.user.findUnique({ where: { email } });
     if (existingUser) {
       throw new AppError(409, "An account with this email already exists");
     }
 
-    // Hash password
     const passwordHash = await bcrypt.hash(password, 12);
-
-    // Generate verification token
     const verificationToken = crypto.randomBytes(32).toString("hex");
     const verificationExpiresAt = new Date(
       Date.now() + VERIFICATION_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
     );
 
-    // Create user (always as student, admin created via seed)
     const user = await prisma.user.create({
       data: {
         email,
@@ -60,10 +61,9 @@ router.post("/register", authLimiter, validate(registerSchema), async (req, res,
         lastName,
         timezone: timezone || "Europe/Madrid",
         isAdmin: false,
-        // Email verification not implemented yet
-        // isEmailVerified: false,
-        // emailVerificationToken: verificationToken,
-        // emailVerificationExpiresAt: verificationExpiresAt,
+        isEmailVerified: false,
+        emailVerificationToken: verificationToken,
+        emailVerificationExpiresAt: verificationExpiresAt,
       },
       select: {
         id: true,
@@ -72,27 +72,27 @@ router.post("/register", authLimiter, validate(registerSchema), async (req, res,
         lastName: true,
         isAdmin: true,
         timezone: true,
-        // isEmailVerified: true,
+        isEmailVerified: true,
         createdAt: true,
         updatedAt: true,
       },
     });
 
-    // Send verification email (non-blocking)
+    // Non-blocking — don't fail registration if email fails
     sendVerificationEmail({
       email: user.email,
       firstName: user.firstName,
       verificationToken,
     }).catch((err) => {
-      console.error("Failed to send verification email:", err);
+      console.error("[auth] Failed to send verification email:", err);
     });
 
     res.status(201).json({
       success: true,
-      message:
-        "Registration successful. Please check your email to verify your account.",
+      message: "Account created! Please check your email to verify your account.",
       data: {
         user,
+        requiresEmailVerification: true,
       },
     });
   } catch (error) {
@@ -100,37 +100,18 @@ router.post("/register", authLimiter, validate(registerSchema), async (req, res,
   }
 });
 
-// POST /api/auth/login
+// ── Login ─────────────────────────────────────────────────────────────────────
+
 router.post("/login", authLimiter, validate(loginSchema), async (req, res, next) => {
   try {
     const { email, password } = req.body;
 
-    // Find user
-    const user = await prisma.user.findUnique({
-      where: { email },
-    });
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) throw new AppError(401, "Invalid email or password");
 
-    if (!user) {
-      throw new AppError(401, "Invalid email or password");
-    }
-
-    // Verify password
     const isValidPassword = await bcrypt.compare(password, user.passwordHash);
+    if (!isValidPassword) throw new AppError(401, "Invalid email or password");
 
-    if (!isValidPassword) {
-      throw new AppError(401, "Invalid email or password");
-    }
-
-    // Email verification not implemented yet
-    // Check if email is verified
-    // if (!user.isEmailVerified) {
-    //   throw new AppError(
-    //     403,
-    //     "Please verify your email before logging in. Check your inbox for the verification link.",
-    //   );
-    // }
-
-    // Prepare user data (without password)
     const userData = {
       id: user.id,
       email: user.email,
@@ -138,39 +119,30 @@ router.post("/login", authLimiter, validate(loginSchema), async (req, res, next)
       lastName: user.lastName,
       isAdmin: user.isAdmin,
       timezone: user.timezone,
-      // isEmailVerified: user.isEmailVerified,
       createdAt: user.createdAt,
       updatedAt: user.updatedAt,
     };
 
-    // Generate token
-    const token = generateToken(userData);
-
-    // Check if admin needs to complete 2FA verification
+    // Admin 2FA gate
     const totpRequired = user.isAdmin && (await isTotpRequired(user.id));
     if (totpRequired) {
-      // Issue a short-lived pre-auth token that only unlocks the 2FA verify endpoint.
-      // The client must hit POST /api/auth/2fa/verify to get the real token.
       const preAuthToken = generateToken({ ...userData, twoFactorPending: true } as any);
       res.cookie("token", preAuthToken, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
         sameSite: "lax",
-        maxAge: 5 * 60 * 1000, // 5 minutes only
+        maxAge: 5 * 60 * 1000,
       });
-      res.json({
-        success: true,
-        data: { totpRequired: true },
-      });
+      res.json({ success: true, data: { totpRequired: true } });
       return;
     }
 
-    // Set HTTP-only cookie
+    const token = generateToken(userData);
     res.cookie("token", token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
       sameSite: "lax",
-      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
+      maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
     res.json({
@@ -178,6 +150,8 @@ router.post("/login", authLimiter, validate(loginSchema), async (req, res, next)
       data: {
         user: userData,
         token,
+        // Soft flag — frontend shows a dismissible banner when false
+        emailVerified: user.isEmailVerified,
       },
     });
   } catch (error) {
@@ -185,160 +159,21 @@ router.post("/login", authLimiter, validate(loginSchema), async (req, res, next)
   }
 });
 
-// GET /api/auth/me
+// ── Me + Logout + Profile ─────────────────────────────────────────────────────
+
 router.get("/me", authenticate, async (req, res) => {
-  res.json({
-    success: true,
-    data: { user: req.user },
-  });
+  res.json({ success: true, data: { user: req.user } });
 });
 
-// POST /api/auth/logout
 router.post("/logout", (req, res) => {
   res.clearCookie("token", {
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
   });
-
-  res.json({
-    success: true,
-    message: "Logged out successfully",
-  });
+  res.json({ success: true, message: "Logged out successfully" });
 });
 
-// POST /api/auth/verify-email
-router.post("/verify-email", async (req, res, next) => {
-  try {
-    const { token } = req.body;
-
-    if (!token || typeof token !== "string") {
-      throw new AppError(400, "Verification token is required");
-    }
-
-    // Email verification not implemented yet - fields don't exist in schema
-    throw new AppError(501, "Email verification is not yet implemented");
-
-    // Find user by verification token
-    // const user = await prisma.user.findUnique({
-    //   where: { emailVerificationToken: token },
-    // });
-
-    // if (!user) {
-    //   throw new AppError(400, "Invalid or expired verification link");
-    // }
-
-    // // Check if token has expired
-    // if (
-    //   user.emailVerificationExpiresAt &&
-    //   user.emailVerificationExpiresAt < new Date()
-    // ) {
-    //   throw new AppError(
-    //     400,
-    //     "Verification link has expired. Please request a new one.",
-    //   );
-    // }
-
-    // // Check if already verified
-    // if (user.isEmailVerified) {
-    //   return res.json({
-    //     success: true,
-    //     message: "Email is already verified. You can now log in.",
-    //   });
-    // }
-
-    // // Update user to verified
-    // await prisma.user.update({
-    //   where: { id: user.id },
-    //   data: {
-    //     isEmailVerified: true,
-    //     emailVerificationToken: null,
-    //     emailVerificationExpiresAt: null,
-    //   },
-    // });
-
-    // res.json({
-    //   success: true,
-    //   message: "Email verified successfully. You can now log in.",
-    // });
-  } catch (error) {
-    next(error);
-  }
-});
-
-// POST /api/auth/resend-verification
-router.post("/resend-verification", async (req, res, next) => {
-  try {
-    const { email } = req.body;
-
-    if (!email || typeof email !== "string") {
-      throw new AppError(400, "Email is required");
-    }
-
-    // Email verification not implemented yet - fields don't exist in schema
-    res.json({
-      success: true,
-      message: "Email verification is not yet implemented.",
-    });
-
-    // Find user by email
-    // const user = await prisma.user.findUnique({
-    //   where: { email },
-    // });
-
-    // // Don't reveal if email exists or not for security
-    // if (!user) {
-    //   return res.json({
-    //     success: true,
-    //     message:
-    //       "If an account with this email exists and is unverified, a new verification email has been sent.",
-    //   });
-    // }
-
-    // // Check if already verified
-    // if (user.isEmailVerified) {
-    //   return res.json({
-    //     success: true,
-    //     message:
-    //       "If an account with this email exists and is unverified, a new verification email has been sent.",
-    //   });
-    // }
-
-    // // Generate new verification token
-    // const verificationToken = crypto.randomBytes(32).toString("hex");
-    // const verificationExpiresAt = new Date(
-    //   Date.now() + VERIFICATION_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
-    // );
-
-    // // Update user with new token
-    // await prisma.user.update({
-    //   where: { id: user.id },
-    //   data: {
-    //     emailVerificationToken: verificationToken,
-    //     emailVerificationExpiresAt: verificationExpiresAt,
-    //   },
-    // });
-
-    // // Send verification email (non-blocking)
-    // sendVerificationEmail({
-    //   email: user.email,
-    //   firstName: user.firstName,
-    //   verificationToken,
-    // }).catch((err) => {
-    //   console.error("Failed to send verification email:", err);
-    // });
-
-    // res.json({
-    //   success: true,
-    //   message:
-    //     "If an account with this email exists and is unverified, a new verification email has been sent.",
-    // });
-  } catch (error) {
-    next(error);
-  }
-});
-
-// PUT /api/auth/profile
 router.put(
   "/profile",
   authenticate,
@@ -346,30 +181,92 @@ router.put(
   async (req, res, next) => {
     try {
       const { firstName, lastName, timezone } = req.body;
-      const userId = req.user!.id;
-
       const updatedUser = await prisma.user.update({
-        where: { id: userId },
+        where: { id: req.user!.id },
         data: {
           ...(firstName !== undefined && { firstName }),
           ...(lastName !== undefined && { lastName }),
           ...(timezone !== undefined && { timezone }),
         },
         select: {
-          id: true,
-          email: true,
-          firstName: true,
-          lastName: true,
-          isAdmin: true,
-          timezone: true,
-          createdAt: true,
-          updatedAt: true,
+          id: true, email: true, firstName: true, lastName: true,
+          isAdmin: true, timezone: true, createdAt: true, updatedAt: true,
         },
+      });
+      res.json({ success: true, data: { user: updatedUser } });
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ── Email verification ────────────────────────────────────────────────────────
+
+router.post(
+  "/verify-email",
+  validate(verifyEmailSchema),
+  async (req, res, next) => {
+    try {
+      const { token } = req.body;
+
+      const user = await prisma.user.findUnique({
+        where: { emailVerificationToken: token },
+      });
+
+      if (!user) {
+        throw new AppError(400, "Invalid or expired verification link.");
+      }
+
+      if (user.emailVerificationExpiresAt && user.emailVerificationExpiresAt < new Date()) {
+        throw new AppError(400, "Verification link has expired. Please request a new one.");
+      }
+
+      if (user.isEmailVerified) {
+        const userData = {
+          id: user.id, email: user.email, firstName: user.firstName,
+          lastName: user.lastName, isAdmin: user.isAdmin, timezone: user.timezone,
+          createdAt: user.createdAt, updatedAt: user.updatedAt,
+        };
+        const authToken = generateToken(userData);
+        res.cookie("token", authToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "lax",
+          maxAge: 7 * 24 * 60 * 60 * 1000,
+        });
+        res.json({
+          success: true,
+          message: "Email already verified.",
+          data: { user: userData, token: authToken, emailVerified: true },
+        });
+        return;
+      }
+
+      const updated = await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          isEmailVerified: true,
+          emailVerificationToken: null,
+          emailVerificationExpiresAt: null,
+        },
+        select: {
+          id: true, email: true, firstName: true, lastName: true,
+          isAdmin: true, timezone: true, createdAt: true, updatedAt: true,
+        },
+      });
+
+      const authToken = generateToken(updated);
+      res.cookie("token", authToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 7 * 24 * 60 * 60 * 1000,
       });
 
       res.json({
         success: true,
-        data: { user: updatedUser },
+        message: "Email verified successfully!",
+        data: { user: updated, token: authToken, emailVerified: true },
       });
     } catch (error) {
       next(error);
@@ -377,9 +274,135 @@ router.put(
   },
 );
 
-// ── 2FA endpoints (admin only) ────────────────────────────────────────────────
+router.post(
+  "/resend-verification",
+  authLimiter,
+  validate(resendVerificationSchema),
+  async (req, res, next) => {
+    try {
+      const { email } = req.body;
+      const SAFE_RESPONSE = {
+        success: true,
+        message: "If an account with this email exists and is unverified, a new verification email has been sent.",
+      };
 
-// GET /api/auth/2fa/setup — generate a TOTP secret + QR code + recovery codes
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user || user.isEmailVerified) {
+        res.json(SAFE_RESPONSE);
+        return;
+      }
+
+      const verificationToken = crypto.randomBytes(32).toString("hex");
+      const verificationExpiresAt = new Date(
+        Date.now() + VERIFICATION_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
+      );
+
+      await prisma.user.update({
+        where: { id: user.id },
+        data: {
+          emailVerificationToken: verificationToken,
+          emailVerificationExpiresAt: verificationExpiresAt,
+        },
+      });
+
+      sendVerificationEmail({
+        email: user.email,
+        firstName: user.firstName,
+        verificationToken,
+      }).catch((err) => {
+        console.error("[auth] Failed to resend verification email:", err);
+      });
+
+      res.json(SAFE_RESPONSE);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+// ── Password reset ────────────────────────────────────────────────────────────
+
+router.post(
+  "/forgot-password",
+  authLimiter,
+  validate(forgotPasswordSchema),
+  async (req, res, next) => {
+    try {
+      const { email } = req.body;
+      const SAFE_RESPONSE = {
+        success: true,
+        message: "If an account exists for this email, a reset link has been sent.",
+      };
+
+      const user = await prisma.user.findUnique({ where: { email } });
+      if (!user) {
+        res.json(SAFE_RESPONSE);
+        return;
+      }
+
+      const resetToken = await createPasswordResetToken(user.id);
+
+      sendPasswordResetEmail({
+        email: user.email,
+        firstName: user.firstName,
+        resetToken,
+      }).catch((err) => {
+        console.error("[auth] Failed to send password reset email:", err);
+      });
+
+      res.json(SAFE_RESPONSE);
+    } catch (error) {
+      next(error);
+    }
+  },
+);
+
+router.post(
+  "/reset-password",
+  authLimiter,
+  validate(resetPasswordSchema),
+  async (req, res, next) => {
+    try {
+      const { token, password } = req.body;
+
+      const userId = await validateAndConsumePasswordResetToken(token);
+
+      const passwordHash = await bcrypt.hash(password, 12);
+
+      const user = await prisma.user.update({
+        where: { id: userId },
+        data: { passwordHash },
+        select: {
+          id: true, email: true, firstName: true, lastName: true,
+          isAdmin: true, timezone: true, createdAt: true, updatedAt: true,
+        },
+      });
+
+      const authToken = generateToken(user);
+      res.cookie("token", authToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "lax",
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      });
+
+      res.json({
+        success: true,
+        message: "Password reset successfully.",
+        data: { user, token: authToken, emailVerified: true },
+      });
+    } catch (error) {
+      // Wrap service errors as 400s
+      if (error instanceof Error && !(error instanceof AppError)) {
+        return next(new AppError(400, error.message));
+      }
+      next(error);
+    }
+  },
+);
+
+// ── 2FA (admin only) ──────────────────────────────────────────────────────────
+
 router.get("/2fa/setup", authenticate, requireAdmin, async (req, res, next) => {
   try {
     const { qrCodeDataUrl, recoveryCodes } = await generateTotpSetup(
@@ -392,8 +415,6 @@ router.get("/2fa/setup", authenticate, requireAdmin, async (req, res, next) => {
   }
 });
 
-// POST /api/auth/2fa/verify — verify code and enable 2FA (first time) OR
-//   complete a login when totpRequired was true in the login response.
 router.post("/2fa/verify", validate(verifyTotpSchema), authenticate, async (req, res, next) => {
   try {
     const { code } = req.body;
@@ -401,26 +422,19 @@ router.post("/2fa/verify", validate(verifyTotpSchema), authenticate, async (req,
     const tf = await prisma.userTwoFactor.findUnique({ where: { userId } });
 
     if (!tf?.enabled) {
-      // Enrollment flow
       const ok = await verifyAndEnableTotp(userId, code);
       if (!ok) throw new AppError(400, "Invalid TOTP code");
       res.json({ success: true, message: "2FA enabled successfully" });
       return;
     }
 
-    // Login-completion flow
     const ok = await verifyTotpCode(userId, code);
     if (!ok) throw new AppError(401, "Invalid TOTP code");
 
     const userData = {
-      id: req.user!.id,
-      email: req.user!.email,
-      firstName: req.user!.firstName,
-      lastName: req.user!.lastName,
-      isAdmin: req.user!.isAdmin,
-      timezone: req.user!.timezone,
-      createdAt: req.user!.createdAt,
-      updatedAt: req.user!.updatedAt,
+      id: req.user!.id, email: req.user!.email, firstName: req.user!.firstName,
+      lastName: req.user!.lastName, isAdmin: req.user!.isAdmin, timezone: req.user!.timezone,
+      createdAt: req.user!.createdAt, updatedAt: req.user!.updatedAt,
     };
     const token = generateToken(userData);
     res.cookie("token", token, {
@@ -435,7 +449,6 @@ router.post("/2fa/verify", validate(verifyTotpSchema), authenticate, async (req,
   }
 });
 
-// POST /api/auth/2fa/recovery — verify a recovery code to bypass TOTP
 router.post(
   "/2fa/recovery",
   validate(verifyTotpWithRecoverySchema),
@@ -445,14 +458,9 @@ router.post(
       const ok = await verifyRecoveryCode(req.user!.id, req.body.code);
       if (!ok) throw new AppError(401, "Invalid recovery code");
       const userData = {
-        id: req.user!.id,
-        email: req.user!.email,
-        firstName: req.user!.firstName,
-        lastName: req.user!.lastName,
-        isAdmin: req.user!.isAdmin,
-        timezone: req.user!.timezone,
-        createdAt: req.user!.createdAt,
-        updatedAt: req.user!.updatedAt,
+        id: req.user!.id, email: req.user!.email, firstName: req.user!.firstName,
+        lastName: req.user!.lastName, isAdmin: req.user!.isAdmin, timezone: req.user!.timezone,
+        createdAt: req.user!.createdAt, updatedAt: req.user!.updatedAt,
       };
       const token = generateToken(userData);
       res.cookie("token", token, {
@@ -468,7 +476,6 @@ router.post(
   },
 );
 
-// POST /api/auth/2fa/disable — admin self-service or emergency reset
 router.post("/2fa/disable", authenticate, requireAdmin, async (req, res, next) => {
   try {
     await disableTotp(req.user!.id);
@@ -479,4 +486,3 @@ router.post("/2fa/disable", authenticate, requireAdmin, async (req, res, next) =
 });
 
 export default router;
-

--- a/packages/backend/src/services/email.ts
+++ b/packages/backend/src/services/email.ts
@@ -1531,3 +1531,97 @@ export async function sendBookingRejectionToStudent(
     throw err;
   }
 }
+
+// ── P0 Auth Flows ──────────────────────────────────────────────────────────────
+
+interface PasswordResetEmailData {
+  email: string;
+  firstName: string;
+  resetToken: string;
+}
+
+export async function sendPasswordResetEmail(
+  data: PasswordResetEmailData,
+): Promise<void> {
+  const { email, firstName, resetToken } = data;
+
+  const resetUrl = `${FRONTEND_URL}/reset-password?token=${resetToken}`;
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a1f36; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: linear-gradient(135deg, #1a1f36 0%, #2d3748 100%); color: white; padding: 30px; text-align: center; border-radius: 12px 12px 0 0; }
+        .content { background: #ffffff; padding: 30px; border: 1px solid #e2e8f0; border-top: none; }
+        .footer { background: #f7fafc; padding: 20px; text-align: center; font-size: 14px; color: #718096; border-radius: 0 0 12px 12px; border: 1px solid #e2e8f0; border-top: none; }
+        .button { display: inline-block; background: #f5a623; color: #1a1f36; padding: 14px 28px; text-decoration: none; border-radius: 8px; font-weight: 600; margin: 20px 0; }
+        .warning { background: #fef2f2; border: 1px solid #fca5a5; padding: 15px; border-radius: 8px; margin: 20px 0; color: #991b1b; }
+        h1 { margin: 0; font-size: 24px; }
+        .emoji { font-size: 32px; margin-bottom: 10px; }
+        .link-text { word-break: break-all; font-size: 12px; color: #718096; margin-top: 15px; }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <div class="header">
+          <div class="emoji">🔐</div>
+          <h1>Reset Your Password</h1>
+        </div>
+        <div class="content">
+          <p>Hi ${firstName},</p>
+          <p>We received a request to reset your Spanish Class account password. Click the button below to choose a new password.</p>
+
+          <div style="text-align: center;">
+            <a href="${resetUrl}" class="button">Reset My Password</a>
+          </div>
+
+          <div class="warning">
+            <strong>This link expires in 1 hour.</strong> If you did not request a password reset, you can safely ignore this email — your password will remain unchanged.
+          </div>
+
+          <p class="link-text">
+            If the button doesn't work, copy and paste this link into your browser:<br>
+            ${resetUrl}
+          </p>
+        </div>
+        <div class="footer">
+          <p>Spanish Class Platform</p>
+          <p>This is an automated message. Please do not reply to this email.</p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+
+  await logEmail({
+    emailType: "password_reset",
+    fromAddress: EMAIL_FROM,
+    toAddress: email,
+    subject: "Reset your password",
+    htmlContent: html,
+    status: "sent",
+  });
+
+  const { error } = await resend.emails.send({
+    from: EMAIL_FROM,
+    to: email,
+    subject: "Reset your password — Spanish Class",
+    html,
+  });
+
+  if (error) {
+    await logEmail({
+      emailType: "password_reset",
+      fromAddress: EMAIL_FROM,
+      toAddress: email,
+      subject: "Reset your password",
+      htmlContent: html,
+      status: "failed",
+      error: error.message,
+    });
+    throw new Error(`Failed to send password reset email: ${error.message}`);
+  }
+}

--- a/packages/backend/src/services/passwordReset.ts
+++ b/packages/backend/src/services/passwordReset.ts
@@ -1,0 +1,51 @@
+import crypto from "crypto";
+import { prisma } from "../lib/prisma.js";
+
+const RESET_TOKEN_EXPIRY_HOURS = 1;
+
+function hashToken(raw: string): string {
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+export async function createPasswordResetToken(userId: string): Promise<string> {
+  // Invalidate all existing pending tokens for this user
+  await prisma.passwordResetToken.deleteMany({
+    where: { userId, usedAt: null },
+  });
+
+  const rawToken = crypto.randomBytes(32).toString("hex");
+  const expiresAt = new Date(
+    Date.now() + RESET_TOKEN_EXPIRY_HOURS * 60 * 60 * 1000,
+  );
+
+  await prisma.passwordResetToken.create({
+    data: {
+      userId,
+      tokenHash: hashToken(rawToken),
+      expiresAt,
+    },
+  });
+
+  return rawToken;
+}
+
+export async function validateAndConsumePasswordResetToken(
+  rawToken: string,
+): Promise<string> {
+  const tokenHash = hashToken(rawToken);
+  const record = await prisma.passwordResetToken.findUnique({
+    where: { tokenHash },
+  });
+
+  if (!record) throw new Error("Invalid or expired reset link.");
+  if (record.usedAt) throw new Error("This reset link has already been used.");
+  if (record.expiresAt < new Date())
+    throw new Error("This reset link has expired. Please request a new one.");
+
+  await prisma.passwordResetToken.update({
+    where: { id: record.id },
+    data: { usedAt: new Date() },
+  });
+
+  return record.userId;
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -26,6 +26,15 @@ const ContactPage = lazy(() =>
 const AuthPage = lazy(() =>
   import("@/pages/auth/AuthPage").then((m) => ({ default: m.AuthPage })),
 );
+const ForgotPasswordPage = lazy(
+  () => import("@/pages/auth/ForgotPasswordPage"),
+);
+const ResetPasswordPage = lazy(
+  () => import("@/pages/auth/ResetPasswordPage"),
+);
+const VerifyEmailPage = lazy(
+  () => import("@/pages/auth/VerifyEmailPage"),
+);
 const DesignShowcase = lazy(() =>
   import("@/pages/DesignShowcase").then((m) => ({
     default: m.DesignShowcase,
@@ -183,6 +192,23 @@ function AppRoutes() {
                 </AuthRedirect>
               }
             />
+            <Route
+              path="/forgot-password"
+              element={
+                <AuthRedirect>
+                  <ForgotPasswordPage />
+                </AuthRedirect>
+              }
+            />
+            <Route
+              path="/reset-password"
+              element={
+                <AuthRedirect>
+                  <ResetPasswordPage />
+                </AuthRedirect>
+              }
+            />
+            <Route path="/verify-email" element={<VerifyEmailPage />} />
             {/* Legacy redirects */}
             <Route path="/login" element={<Navigate to="/auth" replace />} />
             <Route path="/register" element={<Navigate to="/auth" replace />} />

--- a/packages/frontend/src/components/layout/DashboardLayout.tsx
+++ b/packages/frontend/src/components/layout/DashboardLayout.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
+import { EmailVerificationBanner } from "@/components/shared/EmailVerificationBanner";
 import {
   LayoutDashboard,
   Calendar,
@@ -244,6 +245,7 @@ export function DashboardLayout({ isAdmin = false }: DashboardLayoutProps) {
         </div>
 
         {/* Page content */}
+        <EmailVerificationBanner />
         <main className="p-6 sm:p-8 lg:p-12">
           <Outlet />
         </main>

--- a/packages/frontend/src/components/shared/EmailVerificationBanner.tsx
+++ b/packages/frontend/src/components/shared/EmailVerificationBanner.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "react-hot-toast";
+import { MailWarning, X, RefreshCw, Loader2 } from "lucide-react";
+import { useAuthStore } from "@/stores/auth";
+
+export function EmailVerificationBanner() {
+  const { user, emailVerified, resendVerification } = useAuthStore();
+  const [dismissed, setDismissed] = useState(false);
+  const [resending, setResending] = useState(false);
+
+  // Don't render if verified, dismissed, or no user
+  if (!user || emailVerified !== false || dismissed) return null;
+
+  const handleResend = async () => {
+    setResending(true);
+    try {
+      await resendVerification(user.email);
+      toast.success("Verification email sent! Check your inbox.");
+    } catch {
+      toast.error("Failed to send. Please try again.");
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div className="bg-amber-50 border-b border-amber-200 px-4 py-2.5">
+      <div className="max-w-7xl mx-auto flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2 text-amber-800 text-sm">
+          <MailWarning className="w-4 h-4 flex-shrink-0" />
+          <span>
+            Please verify your email address to unlock all features.{" "}
+            <Link to="/verify-email" className="underline font-medium hover:text-amber-900">
+              Check inbox
+            </Link>
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={resending}
+            className="text-xs text-amber-700 hover:text-amber-900 font-medium flex items-center gap-1 disabled:opacity-50"
+          >
+            {resending ? (
+              <><Loader2 className="w-3 h-3 animate-spin" /> Sending…</>
+            ) : (
+              <><RefreshCw className="w-3 h-3" /> Resend verification</>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            className="text-amber-500 hover:text-amber-700"
+            aria-label="Dismiss"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -91,6 +91,40 @@ export const authApi = {
     );
     return res.data.data.user;
   },
+
+  forgotPassword: async (email: string): Promise<{ message: string }> => {
+    const res = await api.post<{ message: string }>("/auth/forgot-password", { email });
+    return res.data;
+  },
+
+  resetPassword: async (
+    token: string,
+    password: string,
+    confirmPassword: string,
+  ): Promise<AuthResponse> => {
+    const res = await api.post<{ data: AuthResponse }>("/auth/reset-password", {
+      token,
+      password,
+      confirmPassword,
+    });
+    if (res.data.data.token) {
+      localStorage.setItem("token", res.data.data.token);
+    }
+    return res.data.data;
+  },
+
+  verifyEmail: async (token: string): Promise<AuthResponse> => {
+    const res = await api.post<{ data: AuthResponse }>("/auth/verify-email", { token });
+    if (res.data.data.token) {
+      localStorage.setItem("token", res.data.data.token);
+    }
+    return res.data.data;
+  },
+
+  resendVerification: async (email: string): Promise<{ message: string }> => {
+    const res = await api.post<{ message: string }>("/auth/resend-verification", { email });
+    return res.data;
+  },
 };
 
 // Professor API

--- a/packages/frontend/src/pages/auth/AuthPage.tsx
+++ b/packages/frontend/src/pages/auth/AuthPage.tsx
@@ -27,12 +27,11 @@ import { PrimaryButton } from "@/components/ui/premium";
 import { useAuthStore } from "@/stores/auth";
 import { cn } from "@/lib/utils";
 
-type AuthMode = "login" | "register";
+type AuthMode = "login" | "register" | "register-success";
 
 export function AuthPage() {
   const { t } = useTranslation("auth");
   const location = useLocation();
-  // Default to login mode
   const [mode, setMode] = useState<AuthMode>("login");
   const [showPassword, setShowPassword] = useState(false);
   const navigate = useNavigate();
@@ -57,7 +56,12 @@ export function AuthPage() {
 
   const onLogin = async (data: LoginInput) => {
     try {
-      await login(data.email, data.password);
+      const result = await login(data.email, data.password);
+      if (result?.totpRequired) {
+        // 2FA gate — leave on this page; backend has issued a short pre-auth cookie
+        toast("Please complete two-factor authentication.", { icon: "🔐" });
+        return;
+      }
       toast.success(t("login.success_message"));
       navigate(from, { replace: true });
     } catch (error: unknown) {
@@ -74,9 +78,13 @@ export function AuthPage() {
 
   const onRegister = async (data: RegisterInput) => {
     try {
-      await registerUser(data);
-      toast.success(t("register.success_message"));
-      navigate("/dashboard");
+      const result = await registerUser(data);
+      if (result?.requiresEmailVerification) {
+        setMode("register-success");
+      } else {
+        toast.success(t("register.success_message"));
+        navigate("/dashboard");
+      }
     } catch (error: unknown) {
       const err = error as { response?: { data?: { error?: string } } };
       toast.error(err.response?.data?.error || t("register.error_default"));
@@ -404,6 +412,14 @@ export function AuthPage() {
                         {loginForm.formState.errors.password.message}
                       </p>
                     )}
+                    <div className="flex justify-end">
+                      <Link
+                        to="/forgot-password"
+                        className="text-xs text-slate-500 hover:text-spanish-teal-600 transition-colors"
+                      >
+                        Forgot password?
+                      </Link>
+                    </div>
                   </div>
 
                   <PrimaryButton
@@ -437,6 +453,35 @@ export function AuthPage() {
                     </button>
                   </p>
                 </div>
+              </motion.div>
+            )}
+
+            {mode === "register-success" && (
+              <motion.div
+                key="register-success"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                className="py-4 text-center"
+              >
+                <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-5">
+                  <CheckCircle2 className="h-8 w-8 text-green-600" />
+                </div>
+                <h2 className="text-xl font-bold text-slate-900 mb-2">Account created!</h2>
+                <p className="text-slate-500 text-sm mb-6">
+                  We've sent a verification email to your inbox. Click the link in the email to
+                  activate your account and start learning.
+                </p>
+                <p className="text-xs text-slate-400 mb-6">
+                  Don't see it? Check your spam folder.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setMode("login")}
+                  className="text-sm text-spanish-teal-600 hover:text-spanish-teal-700 font-medium"
+                >
+                  Go to login
+                </button>
               </motion.div>
             )}
           </AnimatePresence>

--- a/packages/frontend/src/pages/auth/ForgotPasswordPage.tsx
+++ b/packages/frontend/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { motion } from "framer-motion";
+import { Mail, ArrowLeft, CheckCircle2 } from "lucide-react";
+import { forgotPasswordSchema, type ForgotPasswordInput } from "@spanish-class/shared";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { useAuthStore } from "@/stores/auth";
+
+type PageState = "form" | "success";
+
+export default function ForgotPasswordPage() {
+  const [state, setState] = useState<PageState>("form");
+  const { forgotPassword } = useAuthStore();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ForgotPasswordInput>({
+    resolver: zodResolver(forgotPasswordSchema),
+  });
+
+  const onSubmit = async (data: ForgotPasswordInput) => {
+    try {
+      await forgotPassword(data.email);
+      setState("success");
+    } catch {
+      // Always show success to prevent email enumeration
+      setState("success");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-spanish-teal-50 flex items-center justify-center px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="w-full max-w-md"
+      >
+        <div className="bg-white rounded-2xl shadow-xl border border-slate-100 p-8">
+          {state === "form" ? (
+            <>
+              <div className="text-center mb-8">
+                <div className="w-14 h-14 bg-spanish-teal-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <Mail className="w-7 h-7 text-spanish-teal-600" />
+                </div>
+                <h1 className="text-2xl font-bold text-slate-900">Forgot your password?</h1>
+                <p className="text-slate-500 mt-2 text-sm">
+                  Enter your email address and we'll send you a link to reset your password.
+                </p>
+              </div>
+
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+                <div className="space-y-2">
+                  <Label htmlFor="email" className="text-slate-700 font-medium">
+                    Email address
+                  </Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="your@email.com"
+                    autoComplete="email"
+                    className="bg-white border-slate-200 focus:border-spanish-teal-500"
+                    {...register("email")}
+                  />
+                  {errors.email && (
+                    <p className="text-sm text-red-500">{errors.email.message}</p>
+                  )}
+                </div>
+
+                <Button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="w-full bg-spanish-teal-600 hover:bg-spanish-teal-700 text-white font-semibold py-2.5"
+                >
+                  {isSubmitting ? "Sending…" : "Send reset link"}
+                </Button>
+
+                <div className="text-center">
+                  <Link
+                    to="/auth"
+                    className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 transition-colors"
+                  >
+                    <ArrowLeft className="w-4 h-4" />
+                    Back to login
+                  </Link>
+                </div>
+              </form>
+            </>
+          ) : (
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="text-center py-4"
+            >
+              <div className="w-14 h-14 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <CheckCircle2 className="w-7 h-7 text-green-600" />
+              </div>
+              <h2 className="text-xl font-bold text-slate-900 mb-2">Check your inbox</h2>
+              <p className="text-slate-500 text-sm mb-6">
+                If an account exists for that email, we've sent a password reset link.
+                The link expires in <strong>1 hour</strong>.
+              </p>
+              <p className="text-xs text-slate-400 mb-6">
+                Don't see it? Check your spam folder.
+              </p>
+              <Link
+                to="/auth"
+                className="inline-flex items-center gap-1.5 text-sm text-spanish-teal-600 hover:text-spanish-teal-700 font-medium"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Back to login
+              </Link>
+            </motion.div>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/packages/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { motion } from "framer-motion";
+import { toast } from "react-hot-toast";
+import { Lock, Eye, EyeOff, AlertCircle } from "lucide-react";
+import { resetPasswordSchema } from "@spanish-class/shared";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+import { useAuthStore } from "@/stores/auth";
+
+type FieldValues = { token: string; password: string; confirmPassword: string };
+
+export default function ResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+  const navigate = useNavigate();
+  const { resetPassword } = useAuthStore();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FieldValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { token },
+  });
+
+  // Sync hidden token field if URL changes
+  useEffect(() => {
+    if (!token) return;
+  }, [token]);
+
+  if (!token) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-spanish-teal-50 flex items-center justify-center px-4">
+        <div className="bg-white rounded-2xl shadow-xl border border-slate-100 p-8 max-w-md w-full text-center">
+          <AlertCircle className="w-12 h-12 text-red-400 mx-auto mb-4" />
+          <h1 className="text-xl font-bold text-slate-900 mb-2">Invalid reset link</h1>
+          <p className="text-slate-500 text-sm mb-6">
+            This password reset link is missing or invalid. Please request a new one.
+          </p>
+          <Link to="/forgot-password" className="text-spanish-teal-600 hover:text-spanish-teal-700 text-sm font-medium">
+            Request a new reset link
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const onSubmit = async (data: FieldValues) => {
+    try {
+      await resetPassword(data.token, data.password, data.confirmPassword);
+      toast.success("Password reset successfully! Welcome back.");
+      navigate("/dashboard", { replace: true });
+    } catch (error: unknown) {
+      const err = error as { response?: { data?: { error?: string } }; message?: string };
+      toast.error(err.response?.data?.error || err.message || "Failed to reset password. The link may have expired.");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-spanish-teal-50 flex items-center justify-center px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="w-full max-w-md"
+      >
+        <div className="bg-white rounded-2xl shadow-xl border border-slate-100 p-8">
+          <div className="text-center mb-8">
+            <div className="w-14 h-14 bg-spanish-teal-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <Lock className="w-7 h-7 text-spanish-teal-600" />
+            </div>
+            <h1 className="text-2xl font-bold text-slate-900">Set a new password</h1>
+            <p className="text-slate-500 mt-2 text-sm">
+              Choose a strong password for your account.
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            {/* Hidden token field */}
+            <input type="hidden" {...register("token")} value={token} />
+
+            <div className="space-y-2">
+              <Label htmlFor="password" className="text-slate-700 font-medium">
+                New password
+              </Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  placeholder="At least 8 characters"
+                  autoComplete="new-password"
+                  className="pr-10 bg-white border-slate-200 focus:border-spanish-teal-500"
+                  {...register("password")}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                >
+                  {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {errors.password && (
+                <p className="text-sm text-red-500">{errors.password.message}</p>
+              )}
+              <p className="text-xs text-slate-400">
+                Must be at least 8 characters with uppercase, lowercase, and a number.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword" className="text-slate-700 font-medium">
+                Confirm new password
+              </Label>
+              <div className="relative">
+                <Input
+                  id="confirmPassword"
+                  type={showConfirm ? "text" : "password"}
+                  placeholder="Repeat your new password"
+                  autoComplete="new-password"
+                  className="pr-10 bg-white border-slate-200 focus:border-spanish-teal-500"
+                  {...register("confirmPassword")}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirm(!showConfirm)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+                >
+                  {showConfirm ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                </button>
+              </div>
+              {errors.confirmPassword && (
+                <p className="text-sm text-red-500">{errors.confirmPassword.message}</p>
+              )}
+            </div>
+
+            <Button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full bg-spanish-teal-600 hover:bg-spanish-teal-700 text-white font-semibold py-2.5"
+            >
+              {isSubmitting ? "Resetting…" : "Reset password"}
+            </Button>
+          </form>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/auth/VerifyEmailPage.tsx
+++ b/packages/frontend/src/pages/auth/VerifyEmailPage.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { motion } from "framer-motion";
+import { toast } from "react-hot-toast";
+import { CheckCircle2, AlertCircle, Loader2, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuthStore } from "@/stores/auth";
+
+type State = "loading" | "success" | "error" | "no-token";
+
+export default function VerifyEmailPage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") ?? "";
+  const navigate = useNavigate();
+  const { verifyEmail, resendVerification, user } = useAuthStore();
+  const [state, setState] = useState<State>(token ? "loading" : "no-token");
+  const [error, setError] = useState<string>("");
+  const [resending, setResending] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setState("no-token");
+      return;
+    }
+
+    let cancelled = false;
+    verifyEmail(token)
+      .then(() => {
+        if (!cancelled) {
+          setState("success");
+          setTimeout(() => navigate("/dashboard", { replace: true }), 2000);
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          const e = err as { response?: { data?: { error?: string } }; message?: string };
+          setError(e.response?.data?.error || e.message || "Verification failed.");
+          setState("error");
+        }
+      });
+
+    return () => { cancelled = true; };
+  }, [token]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleResend = async () => {
+    const email = user?.email;
+    if (!email) return;
+    setResending(true);
+    try {
+      await resendVerification(email);
+      toast.success("Verification email sent! Check your inbox.");
+    } catch {
+      toast.error("Failed to resend. Please try again.");
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-spanish-teal-50 flex items-center justify-center px-4">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="w-full max-w-md"
+      >
+        <div className="bg-white rounded-2xl shadow-xl border border-slate-100 p-8 text-center">
+          {state === "loading" && (
+            <>
+              <Loader2 className="w-12 h-12 text-spanish-teal-500 mx-auto mb-4 animate-spin" />
+              <h1 className="text-xl font-bold text-slate-900 mb-2">Verifying your email…</h1>
+              <p className="text-slate-500 text-sm">Just a moment.</p>
+            </>
+          )}
+
+          {state === "success" && (
+            <motion.div initial={{ scale: 0.8 }} animate={{ scale: 1 }}>
+              <CheckCircle2 className="w-14 h-14 text-green-500 mx-auto mb-4" />
+              <h1 className="text-2xl font-bold text-slate-900 mb-2">Email verified!</h1>
+              <p className="text-slate-500 text-sm mb-4">
+                Your email has been verified. Redirecting you to your dashboard…
+              </p>
+              <div className="w-full bg-slate-100 rounded-full h-1.5 overflow-hidden">
+                <motion.div
+                  className="h-full bg-green-500 rounded-full"
+                  initial={{ width: 0 }}
+                  animate={{ width: "100%" }}
+                  transition={{ duration: 2 }}
+                />
+              </div>
+            </motion.div>
+          )}
+
+          {state === "error" && (
+            <>
+              <AlertCircle className="w-12 h-12 text-red-400 mx-auto mb-4" />
+              <h1 className="text-xl font-bold text-slate-900 mb-2">Verification failed</h1>
+              <p className="text-slate-500 text-sm mb-6">{error}</p>
+              <div className="space-y-3">
+                {user && (
+                  <Button
+                    onClick={handleResend}
+                    disabled={resending}
+                    className="w-full bg-spanish-teal-600 hover:bg-spanish-teal-700 text-white"
+                  >
+                    {resending ? (
+                      <><Loader2 className="w-4 h-4 mr-2 animate-spin" /> Sending…</>
+                    ) : (
+                      <><RefreshCw className="w-4 h-4 mr-2" /> Resend verification email</>
+                    )}
+                  </Button>
+                )}
+                <Link
+                  to="/auth"
+                  className="block text-sm text-slate-500 hover:text-slate-700"
+                >
+                  Back to login
+                </Link>
+              </div>
+            </>
+          )}
+
+          {state === "no-token" && (
+            <>
+              <AlertCircle className="w-12 h-12 text-amber-400 mx-auto mb-4" />
+              <h1 className="text-xl font-bold text-slate-900 mb-2">Invalid verification link</h1>
+              <p className="text-slate-500 text-sm mb-6">
+                This verification link is missing or malformed. Please use the link from your
+                verification email, or request a new one.
+              </p>
+              <Link to="/auth" className="text-sm text-spanish-teal-600 hover:text-spanish-teal-700 font-medium">
+                Back to login
+              </Link>
+            </>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/packages/frontend/src/stores/auth.ts
+++ b/packages/frontend/src/stores/auth.ts
@@ -7,17 +7,22 @@ interface AuthState {
   user: UserPublic | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  emailVerified: boolean;
   setUser: (user: UserPublic | null) => void;
-  login: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<{ totpRequired?: boolean; emailVerified?: boolean }>;
   register: (data: {
     email: string;
     password: string;
     firstName: string;
     lastName: string;
     timezone?: string;
-  }) => Promise<void>;
+  }) => Promise<{ requiresEmailVerification: boolean }>;
   logout: () => Promise<void>;
   checkAuth: () => Promise<void>;
+  forgotPassword: (email: string) => Promise<void>;
+  resetPassword: (token: string, password: string, confirmPassword: string) => Promise<void>;
+  verifyEmail: (token: string) => Promise<void>;
+  resendVerification: (email: string) => Promise<void>;
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -26,30 +31,38 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       isLoading: true,
       isAuthenticated: false,
+      emailVerified: true,
 
       setUser: (user) =>
-        set({
-          user,
-          isAuthenticated: !!user,
-          isLoading: false,
-        }),
+        set({ user, isAuthenticated: !!user, isLoading: false }),
 
       login: async (email, password) => {
-        const { user } = await authApi.login({ email, password });
-        set({ user, isAuthenticated: true, isLoading: false });
+        const result = await authApi.login({ email, password });
+        if (result.totpRequired) {
+          return { totpRequired: true };
+        }
+        set({
+          user: result.user,
+          isAuthenticated: true,
+          isLoading: false,
+          emailVerified: result.emailVerified !== false,
+        });
+        return { emailVerified: result.emailVerified !== false };
       },
 
       register: async (data) => {
-        const { user } = await authApi.register({
+        const result = await authApi.register({
           ...data,
           timezone: data.timezone || 'Europe/Madrid',
         });
-        set({ user, isAuthenticated: true, isLoading: false });
+        // After register: not auto-logged-in (requires email verification)
+        // result.requiresEmailVerification is true for new users
+        return { requiresEmailVerification: result.requiresEmailVerification ?? false };
       },
 
       logout: async () => {
         await authApi.logout();
-        set({ user: null, isAuthenticated: false });
+        set({ user: null, isAuthenticated: false, emailVerified: true });
       },
 
       checkAuth: async () => {
@@ -59,7 +72,6 @@ export const useAuthStore = create<AuthState>()(
             set({ user: null, isAuthenticated: false, isLoading: false });
             return;
           }
-
           const user = await authApi.me();
           set({ user, isAuthenticated: true, isLoading: false });
         } catch {
@@ -67,10 +79,42 @@ export const useAuthStore = create<AuthState>()(
           set({ user: null, isAuthenticated: false, isLoading: false });
         }
       },
+
+      forgotPassword: async (email) => {
+        await authApi.forgotPassword(email);
+      },
+
+      resetPassword: async (token, password, confirmPassword) => {
+        const result = await authApi.resetPassword(token, password, confirmPassword);
+        set({
+          user: result.user,
+          isAuthenticated: true,
+          isLoading: false,
+          emailVerified: result.emailVerified !== false,
+        });
+      },
+
+      verifyEmail: async (token) => {
+        const result = await authApi.verifyEmail(token);
+        set({
+          user: result.user,
+          isAuthenticated: true,
+          isLoading: false,
+          emailVerified: true,
+        });
+      },
+
+      resendVerification: async (email) => {
+        await authApi.resendVerification(email);
+      },
     }),
     {
       name: 'auth-storage',
-      partialize: (state) => ({ user: state.user, isAuthenticated: state.isAuthenticated }),
-    }
-  )
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+        emailVerified: state.emailVerified,
+      }),
+    },
+  ),
 );

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -405,3 +405,40 @@ export const createReferralSchema = z.object({
 });
 
 export type CreateReferralInput = z.infer<typeof createReferralSchema>;
+
+// ── P0 Auth Flows: Password Reset + Email Verification ───────────────────────
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email("Invalid email address"),
+});
+
+const passwordValidation = z
+  .string()
+  .min(8, "Password must be at least 8 characters")
+  .regex(
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
+    "Password must contain at least one uppercase letter, one lowercase letter, and one number",
+  );
+
+export const resetPasswordSchema = z
+  .object({
+    token: z.string().min(1, "Reset token is required"),
+    password: passwordValidation,
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export const verifyEmailSchema = z.object({
+  token: z.string().min(1, "Verification token is required"),
+});
+
+export const resendVerificationSchema = z.object({
+  email: z.string().email("Invalid email address"),
+});
+
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
+export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
+export type VerifyEmailInput = z.infer<typeof verifyEmailSchema>;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -177,6 +177,9 @@ export interface RegisterData {
 export interface AuthResponse {
   user: UserPublic;
   token: string;
+  emailVerified?: boolean;
+  totpRequired?: boolean;
+  requiresEmailVerification?: boolean;
 }
 
 // Dashboard Stats


### PR DESCRIPTION
Completes the two P0 production-blocking auth gaps. End-to-end verified locally with docker-compose: all flows smoke-tested including replay prevention, auto-login after reset/verify, soft email verification flag.

--- Feature A: Password Reset ---

New DB: password_reset_tokens table (userId, tokenHash SHA-256, expiresAt, usedAt). Raw token stored client-side only; DB stores SHA-256 hash — a DB dump cannot produce valid reset links.

New service: packages/backend/src/services/passwordReset.ts
  - createPasswordResetToken(userId): invalidates all previous pending tokens, creates new 1-hour token, returns raw 64-char hex.
  - validateAndConsumePasswordResetToken(rawToken): verifies hash, expiry, and used-at; marks used on consumption.

New email: sendPasswordResetEmail() in email.ts. Sends HTML email with reset link (${FRONTEND_URL}/reset-password?token=...), 1-hour expiry warning, and email-log audit trail via resend mock in local dev.

New routes on POST /api/auth/forgot-password and /api/auth/reset-password:
  - forgot-password: always 200 regardless of whether email exists (no email enumeration); applies authLimiter.
  - reset-password: validates token, bcrypt-hashes new password, auto-logs-in by returning JWT + setting cookie (same pattern as login).

New frontend pages: ForgotPasswordPage (email input → "check inbox" state), ResetPasswordPage (password + confirm, auto-redirects to dashboard on success). Both added to App.tsx as lazy routes wrapped in AuthRedirect.

--- Feature B: Email Verification ---

DB: added is_email_verified, email_verification_token (unique), email_verification_expires_at to users table. Migration backfills is_email_verified=true for all existing users so they aren't blocked.

Approach: soft enforcement (chose by user). Login returns { emailVerified: false } flag for unverified accounts — they can still log in. Frontend auth store persists emailVerified; DashboardLayout renders an EmailVerificationBanner when emailVerified===false.

Register: now stores emailVerificationToken/ExpiresAt on the user, sends verification email, returns { requiresEmailVerification: true } (no JWT — user must verify to get clean session).

POST /api/auth/verify-email: real implementation (was throwing 501). Finds user by token, checks expiry, sets isEmailVerified=true, clears token fields, auto-logs-in.

POST /api/auth/resend-verification: real implementation (was stub). Always 200 (anti-enumeration). Generates new 24h token, sends email.

New frontend page: VerifyEmailPage — auto-verifies on mount via useEffect, shows loading/success/error states, redirects to dashboard on success. Added as /verify-email (not wrapped in AuthRedirect so authenticated users can also verify).

AuthPage: added "Forgot password?" link below password field; register success now shows "Account created — check inbox" state instead of navigating to dashboard.

--- Shared ---

New schemas: forgotPasswordSchema, resetPasswordSchema, verifyEmailSchema, resendVerificationSchema added to packages/shared/src/schemas.ts. AuthResponse type extended with emailVerified?, totpRequired?, requiresEmailVerification? optional fields.

Generated with Claude Code (https://claude.com/claude-code)