### PR TITLE
feat(booking): configurable cancellation window + no-show marking (PR-6)

### DIFF
--- a/packages/backend/prisma/migrations/20260626120000_pr6_professor_settings_noshow/migration.sql
+++ b/packages/backend/prisma/migrations/20260626120000_pr6_professor_settings_noshow/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE `professor_settings` (
+    `id` VARCHAR(191) NOT NULL,
+    `user_id` VARCHAR(191) NOT NULL,
+    `cancellation_window_hours` INTEGER NOT NULL DEFAULT 24,
+    `no_show_threshold` INTEGER NOT NULL DEFAULT 3,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `professor_settings_user_id_key`(`user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `professor_settings` ADD CONSTRAINT `professor_settings_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -44,6 +44,7 @@ model User {
   twoFactor                UserTwoFactor?
   auditLogsActed           AdminAuditLog[]    @relation("AuditLogsActed")
   passwordResetTokens      PasswordResetToken[]
+  professorSettings        ProfessorSettings?
 
   // Email verification
   isEmailVerified            Boolean   @default(false) @map("is_email_verified")
@@ -418,4 +419,17 @@ model PasswordResetToken {
 
   @@index([userId])
   @@map("password_reset_tokens")
+}
+
+model ProfessorSettings {
+  id                      String   @id @default(cuid())
+  userId                  String   @unique @map("user_id")
+  cancellationWindowHours Int      @default(24) @map("cancellation_window_hours")
+  noShowThreshold         Int      @default(3) @map("no_show_threshold")
+  createdAt               DateTime @default(now()) @map("created_at")
+  updatedAt               DateTime @updatedAt @map("updated_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("professor_settings")
 }

--- a/packages/backend/src/routes/professor.ts
+++ b/packages/backend/src/routes/professor.ts
@@ -1697,4 +1697,162 @@ router.post("/bookings/:id/reject", async (req, res, next) => {
   }
 });
 
+// ── Professor settings ─────────────────────────────────────────────────────
+
+// GET /api/professor/settings — return current settings (upsert defaults on first access)
+router.get("/settings", async (req, res, next) => {
+  try {
+    const settings = await prisma.professorSettings.upsert({
+      where: { userId: req.user!.id },
+      update: {},
+      create: { userId: req.user!.id },
+    });
+    res.json({ success: true, data: { settings } });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PUT /api/professor/settings — update configurable fields
+router.put("/settings", async (req, res, next) => {
+  try {
+    const { cancellationWindowHours, noShowThreshold } = req.body;
+
+    const allowedWindows = [2, 4, 12, 24, 48];
+    if (
+      cancellationWindowHours !== undefined &&
+      !allowedWindows.includes(Number(cancellationWindowHours))
+    ) {
+      res.status(400).json({
+        success: false,
+        error: `cancellationWindowHours must be one of: ${allowedWindows.join(", ")}`,
+      });
+      return;
+    }
+
+    if (
+      noShowThreshold !== undefined &&
+      (Number(noShowThreshold) < 1 || Number(noShowThreshold) > 10)
+    ) {
+      res.status(400).json({
+        success: false,
+        error: "noShowThreshold must be between 1 and 10",
+      });
+      return;
+    }
+
+    const settings = await prisma.professorSettings.upsert({
+      where: { userId: req.user!.id },
+      update: {
+        ...(cancellationWindowHours !== undefined && {
+          cancellationWindowHours: Number(cancellationWindowHours),
+        }),
+        ...(noShowThreshold !== undefined && {
+          noShowThreshold: Number(noShowThreshold),
+        }),
+      },
+      create: {
+        userId: req.user!.id,
+        ...(cancellationWindowHours !== undefined && {
+          cancellationWindowHours: Number(cancellationWindowHours),
+        }),
+        ...(noShowThreshold !== undefined && {
+          noShowThreshold: Number(noShowThreshold),
+        }),
+      },
+    });
+
+    res.json({ success: true, data: { settings } });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// ── No-show marking ────────────────────────────────────────────────────────
+
+// POST /api/professor/bookings/:id/no-show — mark a confirmed past booking as no-show
+router.post("/bookings/:id/no-show", async (req, res, next) => {
+  try {
+    const booking = await prisma.booking.findUnique({
+      where: { id: req.params.id },
+      include: {
+        slot: true,
+        student: {
+          select: {
+            id: true, email: true, firstName: true, lastName: true,
+            isAdmin: true, timezone: true, createdAt: true, updatedAt: true,
+          },
+        },
+      },
+    });
+
+    if (!booking) throw new AppError(404, "Booking not found");
+    if (booking.slot.professorId !== req.user!.id) {
+      throw new AppError(403, "You do not own this booking's slot");
+    }
+    if (booking.status !== "CONFIRMED") {
+      throw new AppError(400, "Only confirmed bookings can be marked as no-show");
+    }
+    if (new Date(booking.slot.startTime) > new Date()) {
+      throw new AppError(400, "Cannot mark no-show before the class has started");
+    }
+
+    await prisma.booking.update({
+      where: { id: booking.id },
+      data: { status: "NO_SHOW" },
+    });
+
+    // Increment student engagement stats
+    await prisma.studentEngagementStats.upsert({
+      where: { studentId: booking.studentId },
+      update: { noShowCount: { increment: 1 } },
+      create: { studentId: booking.studentId, noShowCount: 1 },
+    });
+
+    // Increment professor daily stats for today
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    await prisma.professorDailyStats.upsert({
+      where: { professorId_date: { professorId: req.user!.id, date: today } },
+      update: { noShowClasses: { increment: 1 } },
+      create: { professorId: req.user!.id, date: today, noShowClasses: 1 },
+    });
+
+    // Get updated no-show count and threshold for the professor
+    const [engagementStats, settings] = await Promise.all([
+      prisma.studentEngagementStats.findUnique({
+        where: { studentId: booking.studentId },
+      }),
+      prisma.professorSettings.findUnique({ where: { userId: req.user!.id } }),
+    ]);
+
+    const noShowCount = engagementStats?.noShowCount ?? 1;
+    const threshold = settings?.noShowThreshold ?? 3;
+
+    // Non-blocking email notification to student
+    import("../services/email.js")
+      .then(({ sendNoShowNotificationToStudent }) =>
+        sendNoShowNotificationToStudent({
+          student: booking.student,
+          slot: booking.slot as any,
+        }).catch((err: unknown) =>
+          console.error("[no-show] Failed to send email:", err),
+        ),
+      )
+      .catch(() => {});
+
+    res.json({
+      success: true,
+      message: "Booking marked as no-show",
+      data: {
+        noShowCount,
+        threshold,
+        atThreshold: noShowCount >= threshold,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/packages/backend/src/services/booking.ts
+++ b/packages/backend/src/services/booking.ts
@@ -308,15 +308,19 @@ export async function cancelBooking(
       throw new AppError(403, "You are not authorized to cancel this booking");
     }
 
-    // Check cancellation policy (24 hours before)
+    // Check cancellation policy — window is configurable per professor (default 24h)
+    const professorSettings = await prisma.professorSettings.findUnique({
+      where: { userId: booking.slot.professorId },
+    });
+    const windowHours = professorSettings?.cancellationWindowHours ?? 24;
     const hoursUntilStart =
       (new Date(booking.slot.startTime).getTime() - Date.now()) /
       (1000 * 60 * 60);
 
-    if (hoursUntilStart < 24 && !isAdmin) {
+    if (hoursUntilStart < windowHours && !isAdmin) {
       throw new AppError(
         400,
-        "Bookings must be cancelled at least 24 hours in advance",
+        `Bookings must be cancelled at least ${windowHours} hour${windowHours === 1 ? "" : "s"} in advance`,
       );
     }
 

--- a/packages/backend/src/services/email.ts
+++ b/packages/backend/src/services/email.ts
@@ -1628,3 +1628,85 @@ export async function sendPasswordResetEmail(
     throw new Error(`Failed to send password reset email: ${error.message}`);
   }
 }
+
+// ── No-show notification ───────────────────────────────────────────────────
+
+interface NoShowEmailData {
+  student: Pick<UserPublic, "email" | "firstName" | "lastName">;
+  slot: Pick<AvailabilitySlot, "startTime" | "title">;
+}
+
+export async function sendNoShowNotificationToStudent(
+  data: NoShowEmailData,
+): Promise<void> {
+  const { student, slot } = data;
+  const classDate = formatDateTime(slot.startTime, "Europe/Madrid");
+  const classTitle = slot.title || "Spanish Class";
+
+  const html = `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a1f36; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background: linear-gradient(135deg, #1a1f36 0%, #2d3748 100%); color: white; padding: 30px; text-align: center; border-radius: 12px 12px 0 0; }
+        .content { background: #fff; padding: 30px; border: 1px solid #e2e8f0; border-top: none; }
+        .footer { background: #f7fafc; padding: 20px; text-align: center; font-size: 14px; color: #718096; border-radius: 0 0 12px 12px; border: 1px solid #e2e8f0; border-top: none; }
+        .info-box { background: #fffbeb; border: 1px solid #fbbf24; padding: 15px; border-radius: 8px; margin: 20px 0; color: #92400e; }
+        h1 { margin: 0; font-size: 24px; }
+        .emoji { font-size: 32px; margin-bottom: 10px; }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <div class="header">
+          <div class="emoji">📋</div>
+          <h1>Missed Class Notice</h1>
+        </div>
+        <div class="content">
+          <p>Hi ${student.firstName},</p>
+          <p>We noticed you missed your scheduled class:</p>
+          <div class="info-box">
+            <strong>${classTitle}</strong><br>
+            ${classDate}
+          </div>
+          <p>If this was a mistake or you had an emergency, please reach out to your professor directly to discuss rescheduling.</p>
+          <p>To avoid disruptions for other students, please remember to cancel at least the required number of hours before your class if you're unable to attend.</p>
+        </div>
+        <div class="footer">
+          <p>Spanish Class Platform — We look forward to seeing you next time!</p>
+        </div>
+      </div>
+    </body>
+    </html>
+  `;
+
+  await logEmail({
+    emailType: "no_show_notification",
+    fromAddress: EMAIL_FROM,
+    toAddress: student.email,
+    subject: `Missed class: ${classTitle} — ${classDate}`,
+    htmlContent: html,
+    status: "sent",
+  });
+
+  const { error } = await resend.emails.send({
+    from: EMAIL_FROM,
+    to: student.email,
+    subject: `Missed class: ${classTitle} — ${classDate}`,
+    html,
+  });
+
+  if (error) {
+    await logEmail({
+      emailType: "no_show_notification",
+      fromAddress: EMAIL_FROM,
+      toAddress: student.email,
+      subject: `Missed class: ${classTitle}`,
+      htmlContent: html,
+      status: "failed",
+      error: error.message,
+    });
+  }
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -81,6 +81,9 @@ const EmailLogsPage = lazy(() =>
 const SecuritySettingsPage = lazy(
   () => import("@/pages/admin/SecuritySettingsPage"),
 );
+const ProfessorSettingsPage = lazy(
+  () => import("@/pages/admin/ProfessorSettingsPage"),
+);
 const PendingApprovalsPage = lazy(() =>
   import("@/pages/admin/PendingApprovalsPage").then((m) => ({
     default: m.PendingApprovalsPage,
@@ -240,6 +243,7 @@ function AppRoutes() {
             />
             <Route path="email-logs" element={<EmailLogsPage />} />
             <Route path="settings/security" element={<SecuritySettingsPage />} />
+            <Route path="settings" element={<ProfessorSettingsPage />} />
           </Route>
 
           {/* Student Routes */}

--- a/packages/frontend/src/components/layout/DashboardLayout.tsx
+++ b/packages/frontend/src/components/layout/DashboardLayout.tsx
@@ -15,6 +15,7 @@ import {
   Mail,
   UserCircle,
   Shield,
+  Settings,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -35,6 +36,7 @@ const adminNavItems: NavItem[] = [
   { href: "/admin/slots", label: "Availability", icon: BookOpen },
   { href: "/admin/students", label: "Students", icon: Users },
   { href: "/admin/email-logs", label: "Email Logs", icon: Mail },
+  { href: "/admin/settings", label: "Settings", icon: Settings },
   { href: "/admin/settings/security", label: "Security", icon: Shield },
 ];
 

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -309,6 +309,24 @@ export const professorApi = {
     });
     return res.data.data;
   },
+
+  getSettings: async () => {
+    const res = await api.get("/professor/settings");
+    return res.data.data;
+  },
+
+  updateSettings: async (data: {
+    cancellationWindowHours?: number;
+    noShowThreshold?: number;
+  }) => {
+    const res = await api.put("/professor/settings", data);
+    return res.data.data;
+  },
+
+  markNoShow: async (bookingId: string) => {
+    const res = await api.post(`/professor/bookings/${bookingId}/no-show`);
+    return res.data.data as { noShowCount: number; threshold: number; atThreshold: boolean };
+  },
 };
 
 // Email Log type

--- a/packages/frontend/src/pages/admin/ProfessorSettingsPage.tsx
+++ b/packages/frontend/src/pages/admin/ProfessorSettingsPage.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect } from "react";
+import { toast } from "react-hot-toast";
+import {
+  Settings,
+  Clock,
+  AlertTriangle,
+  Save,
+  Loader2,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { professorApi } from "@/lib/api";
+
+const WINDOW_OPTIONS = [
+  { value: 2, label: "2 hours" },
+  { value: 4, label: "4 hours" },
+  { value: 12, label: "12 hours" },
+  { value: 24, label: "24 hours (recommended)" },
+  { value: 48, label: "48 hours" },
+];
+
+export default function ProfessorSettingsPage() {
+  const [cancellationWindowHours, setCancellationWindowHours] = useState(24);
+  const [noShowThreshold, setNoShowThreshold] = useState(3);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    professorApi
+      .getSettings()
+      .then((data: any) => {
+        const s = data.settings;
+        setCancellationWindowHours(s.cancellationWindowHours);
+        setNoShowThreshold(s.noShowThreshold);
+      })
+      .catch(() => toast.error("Failed to load settings"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await professorApi.updateSettings({
+        cancellationWindowHours,
+        noShowThreshold,
+      });
+      toast.success("Settings saved!");
+    } catch {
+      toast.error("Failed to save settings.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Loader2 className="w-8 h-8 animate-spin text-slate-400" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div className="flex items-center gap-3 mb-2">
+        <Settings className="w-7 h-7 text-spanish-teal-600" />
+        <h1 className="text-2xl font-bold text-slate-900">Professor Settings</h1>
+      </div>
+
+      {/* Cancellation window */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Clock className="w-5 h-5 text-slate-500" />
+            Cancellation Policy
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="window">Minimum notice for cancellation</Label>
+            <Select
+              value={String(cancellationWindowHours)}
+              onValueChange={(v) => setCancellationWindowHours(Number(v))}
+            >
+              <SelectTrigger id="window" className="w-full max-w-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {WINDOW_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={String(opt.value)}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-slate-500">
+              Students must cancel at least this many hours before the class starts. Admin
+              cancellations bypass this restriction.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* No-show threshold */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <AlertTriangle className="w-5 h-5 text-amber-500" />
+            No-Show Threshold
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="threshold">Alert after this many no-shows</Label>
+            <Input
+              id="threshold"
+              type="number"
+              min={1}
+              max={10}
+              value={noShowThreshold}
+              onChange={(e) => setNoShowThreshold(Number(e.target.value))}
+              className="w-24"
+            />
+            <p className="text-xs text-slate-500">
+              When a student reaches this number of no-shows, you'll be notified in the
+              Mark No-Show response. Range: 1–10.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end">
+        <Button
+          onClick={handleSave}
+          disabled={saving}
+          className="bg-spanish-teal-600 hover:bg-spanish-teal-700 text-white"
+        >
+          {saving ? (
+            <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+          ) : (
+            <Save className="w-4 h-4 mr-2" />
+          )}
+          Save settings
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/admin/StudentDetailPage.tsx
+++ b/packages/frontend/src/pages/admin/StudentDetailPage.tsx
@@ -368,17 +368,43 @@ export function StudentDetailPage() {
                       </p>
                     </div>
                   </div>
-                  <Badge
-                    variant={
-                      booking.status === "CONFIRMED"
-                        ? "success"
-                        : booking.status === "COMPLETED"
-                          ? "neutral"
-                          : "destructive"
-                    }
-                  >
-                    {booking.status}
-                  </Badge>
+                  <div className="flex items-center gap-2">
+                    <Badge
+                      variant={
+                        booking.status === "CONFIRMED"
+                          ? "success"
+                          : booking.status === "COMPLETED"
+                            ? "neutral"
+                            : "destructive"
+                      }
+                    >
+                      {booking.status}
+                    </Badge>
+                    {booking.status === "CONFIRMED" &&
+                      booking.slot?.startTime &&
+                      new Date(booking.slot.startTime) < new Date() && (
+                        <button
+                          type="button"
+                          className="text-xs px-2 py-1 rounded border border-amber-300 text-amber-700 hover:bg-amber-50 transition-colors"
+                          onClick={async () => {
+                            if (!confirm("Mark this booking as no-show?")) return;
+                            try {
+                              const result = await professorApi.markNoShow(booking.id);
+                              toast.success(
+                                result.atThreshold
+                                  ? `Marked as no-show. Student has reached the no-show threshold (${result.noShowCount}/${result.threshold}).`
+                                  : `Marked as no-show (${result.noShowCount}/${result.threshold} no-shows).`,
+                              );
+                              queryClient.invalidateQueries({ queryKey: ["student", id] });
+                            } catch (err: any) {
+                              toast.error(err?.response?.data?.error || "Failed to mark no-show");
+                            }
+                          }}
+                        >
+                          Mark No-Show
+                        </button>
+                      )}
+                  </div>
                 </CardContent>
               </Card>
             ))


### PR DESCRIPTION
--- 6A: Configurable Cancellation Window ---

New ProfessorSettings model (professor_settings table): userId (unique FK to users), cancellationWindowHours (default 24), noShowThreshold (default 3).

Migration: 20260626120000_pr6_professor_settings_noshow — CREATE TABLE professor_settings with FK + CASCADE delete.

booking.ts cancelBooking(): replaced hardcoded 24h check with a DB lookup of ProfessorSettings.cancellationWindowHours for the slot's professor. Falls back to 24h if no settings row exists. Error message is dynamic: "Bookings must be cancelled at least Nh in advance".

New endpoints on professor router (behind authenticate+requireAdmin):
  GET /api/professor/settings — upserts defaults on first access, returns
    { settings: { cancellationWindowHours, noShowThreshold, ... } }
  PUT /api/professor/settings — validates cancellationWindowHours ∈
    {2,4,12,24,48} and noShowThreshold ∈ [1,10], upserts.

New ProfessorSettingsPage (frontend): Select for cancellation window (5 options), number input for no-show threshold, save button. Loaded from GET /api/professor/settings on mount. Route: /admin/settings (lazy-loaded). "Settings" nav item (Settings icon) added to admin sidebar.

New professorApi methods: getSettings(), updateSettings(), markNoShow().

--- 6B: No-Show Marking by Professor ---

New endpoint: POST /api/professor/bookings/:id/no-show
  - Verifies professor owns the slot
  - Requires booking.status === CONFIRMED
  - Requires slot.startTime in the past (can't mark no-show before class)
  - Sets booking.status = NO_SHOW
  - Upserts StudentEngagementStats.noShowCount += 1
  - Upserts ProfessorDailyStats.noShowClasses += 1 for today
  - Returns { noShowCount, threshold, atThreshold } so professor knows if student has reached the no-show threshold
  - Non-blocking: sends no-show email to student

New email: sendNoShowNotificationToStudent() — friendly notice to student about the missed class, encourages rescheduling or contacting professor. Logs to EmailLog with type "no_show_notification".

Frontend (StudentDetailPage): "Mark No-Show" button appears on CONFIRMED bookings where slot.startTime < now. One-click with confirm dialog; shows no-show count + threshold warning in success toast; invalidates query.

Generated with Claude Code (https://claude.com/claude-code)