### PR TITLE
feat(booking+ux): waitlist, i18n language switcher, in-app notificati…

### DIFF
--- a/packages/backend/prisma/migrations/20260626150000_pr7_pr8_waitlist_notifications/migration.sql
+++ b/packages/backend/prisma/migrations/20260626150000_pr7_pr8_waitlist_notifications/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE `waitlist_entries` (
+    `id` VARCHAR(191) NOT NULL,
+    `slot_id` VARCHAR(191) NOT NULL,
+    `user_id` VARCHAR(191) NOT NULL,
+    `position` INTEGER NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `notified_at` DATETIME(3) NULL,
+
+    INDEX `waitlist_entries_slot_id_position_idx`(`slot_id`, `position`),
+    UNIQUE INDEX `waitlist_entries_slot_id_user_id_key`(`slot_id`, `user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `notifications` (
+    `id` VARCHAR(191) NOT NULL,
+    `user_id` VARCHAR(191) NOT NULL,
+    `type` VARCHAR(50) NOT NULL,
+    `title` VARCHAR(200) NOT NULL,
+    `body` TEXT NOT NULL,
+    `href` VARCHAR(500) NULL,
+    `read_at` DATETIME(3) NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `notifications_user_id_read_at_idx`(`user_id`, `read_at`),
+    INDEX `notifications_user_id_created_at_idx`(`user_id`, `created_at`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `waitlist_entries` ADD CONSTRAINT `waitlist_entries_slot_id_fkey` FOREIGN KEY (`slot_id`) REFERENCES `availability_slots`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `waitlist_entries` ADD CONSTRAINT `waitlist_entries_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `notifications` ADD CONSTRAINT `notifications_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/packages/backend/prisma/schema.prisma
+++ b/packages/backend/prisma/schema.prisma
@@ -45,6 +45,8 @@ model User {
   auditLogsActed           AdminAuditLog[]    @relation("AuditLogsActed")
   passwordResetTokens      PasswordResetToken[]
   professorSettings        ProfessorSettings?
+  waitlistEntries          WaitlistEntry[]
+  notifications            Notification[]
 
   // Email verification
   isEmailVerified            Boolean   @default(false) @map("is_email_verified")
@@ -76,6 +78,7 @@ model AvailabilitySlot {
   bookings         Booking[]
   allowedStudents  SlotAllowedStudent[]
   recurringPattern RecurringPattern? @relation(fields: [recurringPatternId], references: [id])
+  waitlistEntries  WaitlistEntry[]
 
   @@index([professorId])
   @@index([startTime])
@@ -432,4 +435,41 @@ model ProfessorSettings {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@map("professor_settings")
+}
+
+// ── PR-7: Waitlist ────────────────────────────────────────────────────────────
+
+model WaitlistEntry {
+  id         String    @id @default(cuid())
+  slotId     String    @map("slot_id")
+  userId     String    @map("user_id")
+  position   Int
+  createdAt  DateTime  @default(now()) @map("created_at")
+  notifiedAt DateTime? @map("notified_at")
+
+  slot AvailabilitySlot @relation(fields: [slotId], references: [id], onDelete: Cascade)
+  user User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([slotId, userId])
+  @@index([slotId, position])
+  @@map("waitlist_entries")
+}
+
+// ── PR-8: Notifications ───────────────────────────────────────────────────────
+
+model Notification {
+  id        String    @id @default(cuid())
+  userId    String    @map("user_id")
+  type      String    @db.VarChar(50)
+  title     String    @db.VarChar(200)
+  body      String    @db.Text
+  href      String?   @db.VarChar(500)
+  readAt    DateTime? @map("read_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, readAt])
+  @@index([userId, createdAt])
+  @@map("notifications")
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,6 +8,7 @@ import { authLimiter, generalLimiter } from "./middleware/rateLimiter.js";
 import authRoutes from "./routes/auth.js";
 import professorRoutes from "./routes/professor.js";
 import studentRoutes from "./routes/student.js";
+import notificationsRoutes from "./routes/notifications.js";
 
 const app: Express = express();
 const PORT = process.env.PORT || 3001;
@@ -81,6 +82,7 @@ app.get("/health", (_, res) => {
 app.use("/api/auth", authRoutes);
 app.use("/api/professor", professorRoutes);
 app.use("/api/student", studentRoutes);
+app.use("/api/notifications", notificationsRoutes);
 
 // ── Error handling ────────────────────────────────────────────────────────────
 app.use(notFoundHandler);

--- a/packages/backend/src/routes/notifications.ts
+++ b/packages/backend/src/routes/notifications.ts
@@ -1,0 +1,76 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.js";
+import {
+  addSSEConnection,
+  removeSSEConnection,
+  markRead,
+  markAllRead,
+  getNotifications,
+} from "../services/notifications.js";
+
+const router = Router();
+
+// All notification routes require authentication
+router.use(authenticate);
+
+// GET /api/notifications — list last 30 notifications
+router.get("/", async (req, res, next) => {
+  try {
+    const notifications = await getNotifications(req.user!.id);
+    res.json({ success: true, data: { notifications } });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// PUT /api/notifications/:id/read — mark one as read
+router.put("/:id/read", async (req, res, next) => {
+  try {
+    await markRead(req.params.id, req.user!.id);
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// POST /api/notifications/read-all — mark all as read
+router.post("/read-all", async (req, res, next) => {
+  try {
+    await markAllRead(req.user!.id);
+    res.json({ success: true });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// GET /api/notifications/stream — SSE endpoint
+router.get("/stream", (req, res) => {
+  const userId = req.user!.id;
+
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  res.setHeader("X-Accel-Buffering", "no"); // disable nginx buffering
+  res.flushHeaders();
+
+  // Send initial "connected" ping
+  res.write("event: connected\ndata: {}\n\n");
+
+  addSSEConnection(userId, res);
+
+  // Keepalive every 25 seconds to prevent proxy/browser timeout
+  const keepalive = setInterval(() => {
+    try {
+      res.write(":\n\n"); // SSE comment = keepalive
+    } catch {
+      clearInterval(keepalive);
+    }
+  }, 25_000);
+
+  req.on("close", () => {
+    clearInterval(keepalive);
+    removeSSEConnection(userId, res);
+  });
+});
+
+export default router;

--- a/packages/backend/src/routes/professor.ts
+++ b/packages/backend/src/routes/professor.ts
@@ -1855,4 +1855,29 @@ router.post("/bookings/:id/no-show", async (req, res, next) => {
   }
 });
 
+// GET /api/professor/slots/:id/waitlist — view waitlist for a slot
+router.get("/slots/:id/waitlist", async (req, res, next) => {
+  try {
+    const slot = await prisma.availabilitySlot.findUnique({
+      where: { id: req.params.id },
+      select: { professorId: true },
+    });
+    if (!slot || slot.professorId !== req.user!.id) {
+      throw new AppError(404, "Slot not found");
+    }
+    const entries = await prisma.waitlistEntry.findMany({
+      where: { slotId: req.params.id },
+      orderBy: { position: "asc" },
+      include: {
+        user: {
+          select: { id: true, email: true, firstName: true, lastName: true, createdAt: true },
+        },
+      },
+    });
+    res.json({ success: true, data: { waitlist: entries, count: entries.length } });
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/packages/backend/src/routes/student.ts
+++ b/packages/backend/src/routes/student.ts
@@ -230,7 +230,16 @@ router.post(
   async (req, res, next) => {
     try {
       const result = await bookSlot(req.body.slotId, req.user!);
-
+      // Waitlist result — slot was full, student added to queue
+      if ("waitlisted" in result && result.waitlisted) {
+        res.status(202).json({
+          success: true,
+          waitlisted: true,
+          data: { position: result.position, slotId: result.slotId },
+          message: `You've been added to the waitlist at position ${result.position}. We'll notify you if a spot opens up.`,
+        });
+        return;
+      }
       res.status(201).json({
         success: true,
         data: result,
@@ -568,5 +577,47 @@ router.put(
     }
   },
 );
+
+// ── Waitlist ──────────────────────────────────────────────────────────────────
+
+// GET /api/student/slots/:id/waitlist-position
+router.get("/slots/:id/waitlist-position", async (req, res, next) => {
+  try {
+    const entry = await prisma.waitlistEntry.findUnique({
+      where: { slotId_userId: { slotId: req.params.id, userId: req.user!.id } },
+    });
+    res.json({
+      success: true,
+      data: { position: entry?.position ?? null, waitlisted: !!entry },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+// DELETE /api/student/slots/:id/waitlist — leave waitlist
+router.delete("/slots/:id/waitlist", async (req, res, next) => {
+  try {
+    const entry = await prisma.waitlistEntry.findUnique({
+      where: { slotId_userId: { slotId: req.params.id, userId: req.user!.id } },
+    });
+    if (!entry) {
+      res.status(404).json({ success: false, error: "You are not on the waitlist for this slot" });
+      return;
+    }
+    await prisma.waitlistEntry.delete({ where: { id: entry.id } });
+    // Resequence remaining entries
+    const remaining = await prisma.waitlistEntry.findMany({
+      where: { slotId: req.params.id },
+      orderBy: { position: "asc" },
+    });
+    for (let i = 0; i < remaining.length; i++) {
+      await prisma.waitlistEntry.update({ where: { id: remaining[i].id }, data: { position: i + 1 } });
+    }
+    res.json({ success: true, message: "Removed from waitlist" });
+  } catch (error) {
+    next(error);
+  }
+});
 
 export default router;

--- a/packages/backend/src/services/booking.ts
+++ b/packages/backend/src/services/booking.ts
@@ -9,9 +9,12 @@ import {
   sendCancellationToProfessor,
   sendConfirmationRequestToProfessor,
   sendPendingConfirmationToStudent,
+  sendWaitlistConfirmationToStudent,
+  sendWaitlistPromotionToStudent,
 } from "./email.js";
 import { createMeetingRoom, getMeetingProvider } from "./meeting-provider.js";
 import { generateConfirmationToken } from "./confirmation-token.js";
+import { createNotification } from "./notifications.js";
 
 type TransactionClient = Prisma.TransactionClient;
 
@@ -25,6 +28,12 @@ interface BookSlotResult {
     meetLink: string | null;
     meetingUrl: string | null;
   };
+}
+
+interface WaitlistResult {
+  waitlisted: true;
+  position: number;
+  slotId: string;
 }
 
 /**
@@ -174,7 +183,55 @@ async function attemptBooking(
 export async function bookSlot(
   slotId: string,
   student: UserPublic,
-): Promise<BookSlotResult> {
+): Promise<BookSlotResult | WaitlistResult> {
+  // Check for fully-booked group slots BEFORE the retry loop — waitlist is not a conflict
+  const slotForWaitlist = await prisma.availabilitySlot.findUnique({
+    where: { id: slotId },
+    select: { status: true, slotType: true, maxParticipants: true, currentParticipants: true, startTime: true },
+  });
+  if (
+    slotForWaitlist &&
+    slotForWaitlist.slotType === "GROUP" &&
+    (slotForWaitlist.status === "FULLY_BOOKED" ||
+      slotForWaitlist.currentParticipants >= slotForWaitlist.maxParticipants)
+  ) {
+    // Check the slot is in the future
+    if (new Date(slotForWaitlist.startTime) <= new Date()) {
+      throw new AppError(400, "Cannot join waitlist for a past slot");
+    }
+    // Check student isn't already waitlisted
+    const existing = await prisma.waitlistEntry.findUnique({
+      where: { slotId_userId: { slotId, userId: student.id } },
+    });
+    if (existing) {
+      throw new AppError(409, `You are already on the waitlist at position ${existing.position}`);
+    }
+    // Check student doesn't already have a booking for this slot
+    const existingBooking = await prisma.booking.findFirst({
+      where: { slotId, studentId: student.id, status: { notIn: ["CANCELLED_BY_STUDENT", "CANCELLED_BY_PROFESSOR", "REJECTED", "EXPIRED"] } },
+    });
+    if (existingBooking) {
+      throw new AppError(409, "You already have a booking for this slot");
+    }
+    const position = (await prisma.waitlistEntry.count({ where: { slotId } })) + 1;
+    await prisma.waitlistEntry.create({ data: { slotId, userId: student.id, position } });
+
+    // Get slot details for the email
+    const slotForEmail = await prisma.availabilitySlot.findUnique({
+      where: { id: slotId },
+      include: { professor: { select: { id: true, email: true, firstName: true, lastName: true, isAdmin: true, timezone: true, createdAt: true, updatedAt: true } } },
+    });
+    if (slotForEmail) {
+      sendWaitlistConfirmationToStudent({
+        student,
+        slot: slotForEmail as any,
+        professor: slotForEmail.professor as any,
+        position,
+      }).catch((e: unknown) => console.error("[waitlist] email failed:", e));
+    }
+    return { waitlisted: true, position, slotId };
+  }
+
   const maxRetries = 3;
   let lastError: Error | null = null;
 
@@ -218,6 +275,12 @@ export async function bookSlot(
       ]).catch((err: unknown) =>
         console.error("Failed to send booking emails:", err),
       );
+
+      // Fire in-app notifications (non-blocking)
+      const slotTitle = slot.title || "Spanish Class";
+      const classDate = new Date(slot.startTime).toLocaleDateString("en", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+      createNotification(student.id, "booking_pending", "Booking pending confirmation", `Your booking for ${slotTitle} on ${classDate} is awaiting professor confirmation.`, "/dashboard/bookings").catch(() => {});
+      createNotification(slot.professor.id, "booking_request", "New booking request", `${student.firstName} ${student.lastName} has requested to book ${slotTitle} on ${classDate}.`, "/admin").catch(() => {});
 
       return {
         bookingId: booking.id,
@@ -349,10 +412,28 @@ export async function cancelBooking(
       },
     });
 
-    return { booking, cancelledBy };
+    // Promote first waitlist entry (if any) for group slots
+    const nextWaiting = await tx.waitlistEntry.findFirst({
+      where: { slotId: booking.slotId },
+      orderBy: { position: "asc" },
+      include: {
+        user: { select: { id: true, email: true, firstName: true, lastName: true, isAdmin: true, timezone: true, createdAt: true, updatedAt: true } },
+      },
+    });
+
+    if (nextWaiting) {
+      await tx.waitlistEntry.delete({ where: { id: nextWaiting.id } });
+      // Resequence remaining entries
+      const remaining = await tx.waitlistEntry.findMany({ where: { slotId: booking.slotId }, orderBy: { position: "asc" } });
+      for (let i = 0; i < remaining.length; i++) {
+        await tx.waitlistEntry.update({ where: { id: remaining[i].id }, data: { position: i + 1 } });
+      }
+    }
+
+    return { booking, cancelledBy, promotedWaitlistEntry: nextWaiting || null };
   });
 
-  const { booking, cancelledBy } = result;
+  const { booking, cancelledBy, promotedWaitlistEntry } = result;
 
   // Send cancellation emails
   // Cast slot to fix Prisma enum vs shared enum type mismatch
@@ -377,4 +458,13 @@ export async function cancelBooking(
   ]).catch((err: unknown) =>
     console.error("Failed to send cancellation emails:", err),
   );
+
+  // If someone was promoted from the waitlist, notify them
+  if (promotedWaitlistEntry) {
+    sendWaitlistPromotionToStudent({
+      student: promotedWaitlistEntry.user as unknown as import("@spanish-class/shared").UserPublic,
+      slot: cancelSlotForEmail,
+      professor: booking.slot.professor as unknown as import("@spanish-class/shared").UserPublic,
+    }).catch((e: unknown) => console.error("[waitlist] promotion email failed:", e));
+  }
 }

--- a/packages/backend/src/services/email.ts
+++ b/packages/backend/src/services/email.ts
@@ -1710,3 +1710,75 @@ export async function sendNoShowNotificationToStudent(
     });
   }
 }
+
+// ── Waitlist emails ────────────────────────────────────────────────────────────
+
+interface WaitlistEmailData {
+  student: Pick<UserPublic, "email" | "firstName">;
+  slot: Pick<AvailabilitySlot, "startTime" | "endTime" | "title">;
+  professor: Pick<UserPublic, "firstName" | "lastName" | "timezone">;
+  position?: number;
+}
+
+export async function sendWaitlistConfirmationToStudent(
+  data: WaitlistEmailData & { position: number },
+): Promise<void> {
+  const { student, slot, professor, position } = data;
+  const classDate = formatDateTime(slot.startTime, professor.timezone);
+  const classTitle = slot.title || "Spanish Class";
+
+  const html = `
+    <!DOCTYPE html><html><head><style>
+      body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.6;color:#1a1f36}
+      .container{max-width:600px;margin:0 auto;padding:20px}
+      .header{background:linear-gradient(135deg,#1a1f36 0%,#2d3748 100%);color:white;padding:30px;text-align:center;border-radius:12px 12px 0 0}
+      .content{background:#fff;padding:30px;border:1px solid #e2e8f0;border-top:none}
+      .footer{background:#f7fafc;padding:20px;text-align:center;font-size:14px;color:#718096;border-radius:0 0 12px 12px;border:1px solid #e2e8f0;border-top:none}
+      .badge{display:inline-block;background:#f0fdf4;border:1px solid #86efac;color:#166534;padding:8px 16px;border-radius:8px;font-size:18px;font-weight:700;margin:16px 0}
+      h1{margin:0;font-size:24px}.emoji{font-size:32px;margin-bottom:10px}
+    </style></head><body>
+    <div class="container">
+      <div class="header"><div class="emoji">📋</div><h1>You're on the Waitlist</h1></div>
+      <div class="content">
+        <p>Hi ${student.firstName},</p>
+        <p><strong>${classTitle}</strong> on ${classDate} is currently full, but you've been added to the waitlist.</p>
+        <div class="badge">Position #${position}</div>
+        <p>If a spot opens up, you'll receive an automatic notification and a booking request will be sent to the professor for confirmation.</p>
+        <p>You can remove yourself from the waitlist at any time from your bookings page.</p>
+      </div>
+      <div class="footer"><p>Spanish Class Platform</p></div>
+    </div></body></html>`;
+
+  await logEmail({ emailType: "waitlist_confirmation", fromAddress: EMAIL_FROM, toAddress: student.email, subject: `Waitlist confirmation: ${classTitle} (position #${position})`, htmlContent: html, status: "sent" });
+  await resend.emails.send({ from: EMAIL_FROM, to: student.email, subject: `Waitlist confirmation: ${classTitle} (position #${position})`, html });
+}
+
+export async function sendWaitlistPromotionToStudent(data: WaitlistEmailData): Promise<void> {
+  const { student, slot, professor } = data;
+  const classDate = formatDateTime(slot.startTime, professor.timezone);
+  const classTitle = slot.title || "Spanish Class";
+
+  const html = `
+    <!DOCTYPE html><html><head><style>
+      body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.6;color:#1a1f36}
+      .container{max-width:600px;margin:0 auto;padding:20px}
+      .header{background:linear-gradient(135deg,#1a1f36 0%,#2d3748 100%);color:white;padding:30px;text-align:center;border-radius:12px 12px 0 0}
+      .content{background:#fff;padding:30px;border:1px solid #e2e8f0;border-top:none}
+      .footer{background:#f7fafc;padding:20px;text-align:center;font-size:14px;color:#718096;border-radius:0 0 12px 12px;border:1px solid #e2e8f0;border-top:none}
+      .info-box{background:#f0fdf4;border:1px solid #86efac;padding:15px;border-radius:8px;margin:20px 0;color:#166534}
+      h1{margin:0;font-size:24px}.emoji{font-size:32px;margin-bottom:10px}
+    </style></head><body>
+    <div class="container">
+      <div class="header"><div class="emoji">🎉</div><h1>A Spot Opened Up!</h1></div>
+      <div class="content">
+        <p>Hi ${student.firstName},</p>
+        <p>Great news — a spot opened up in <strong>${classTitle}</strong>.</p>
+        <div class="info-box"><strong>${classTitle}</strong><br>${classDate}</div>
+        <p>A booking request has been automatically sent to your professor for confirmation. You'll receive a confirmation email once the professor approves.</p>
+      </div>
+      <div class="footer"><p>Spanish Class Platform</p></div>
+    </div></body></html>`;
+
+  await logEmail({ emailType: "waitlist_promotion", fromAddress: EMAIL_FROM, toAddress: student.email, subject: `Spot opened: ${classTitle}`, htmlContent: html, status: "sent" });
+  await resend.emails.send({ from: EMAIL_FROM, to: student.email, subject: `Good news — a spot opened up in ${classTitle}`, html });
+}

--- a/packages/backend/src/services/notifications.ts
+++ b/packages/backend/src/services/notifications.ts
@@ -1,0 +1,63 @@
+import { Response } from "express";
+import { prisma } from "../lib/prisma.js";
+
+// In-memory SSE connections: userId → Set of response objects
+const connections = new Map<string, Set<Response>>();
+
+export function addSSEConnection(userId: string, res: Response): void {
+  if (!connections.has(userId)) connections.set(userId, new Set());
+  connections.get(userId)!.add(res);
+}
+
+export function removeSSEConnection(userId: string, res: Response): void {
+  connections.get(userId)?.delete(res);
+  if (connections.get(userId)?.size === 0) connections.delete(userId);
+}
+
+function push(userId: string, eventName: string, data: unknown): void {
+  const conns = connections.get(userId);
+  if (!conns) return;
+  const payload = `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+  for (const res of conns) {
+    try {
+      res.write(payload);
+    } catch {
+      conns.delete(res);
+    }
+  }
+}
+
+export async function createNotification(
+  userId: string,
+  type: string,
+  title: string,
+  body: string,
+  href?: string,
+): Promise<void> {
+  const notification = await prisma.notification.create({
+    data: { userId, type, title, body, href: href ?? null },
+  });
+  push(userId, "notification", notification);
+}
+
+export async function markRead(id: string, userId: string): Promise<void> {
+  await prisma.notification.updateMany({
+    where: { id, userId },
+    data: { readAt: new Date() },
+  });
+}
+
+export async function markAllRead(userId: string): Promise<void> {
+  await prisma.notification.updateMany({
+    where: { userId, readAt: null },
+    data: { readAt: new Date() },
+  });
+}
+
+export async function getNotifications(userId: string, limit = 30) {
+  return prisma.notification.findMany({
+    where: { userId },
+    orderBy: [{ readAt: "asc" }, { createdAt: "desc" }],
+    take: limit,
+  });
+}

--- a/packages/frontend/src/components/layout/DashboardLayout.tsx
+++ b/packages/frontend/src/components/layout/DashboardLayout.tsx
@@ -1,8 +1,11 @@
 import { useState } from "react";
 import { Link, Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import i18n from "@/lib/i18n";
+import { updateLanguagePreference } from "@/lib/api";
 import { motion, AnimatePresence } from "framer-motion";
 import { EmailVerificationBanner } from "@/components/shared/EmailVerificationBanner";
+import { NotificationBell } from "@/components/shared/NotificationBell";
 import {
   LayoutDashboard,
   Calendar,
@@ -162,9 +165,34 @@ export function DashboardLayout({ isAdmin = false }: DashboardLayoutProps) {
             </div>
           )}
 
+          {/* Language switcher */}
+          {!collapsed && (
+            <div className="px-4 py-2 border-b border-slate-100">
+              <div className="flex items-center gap-1">
+                {(["en", "sr", "es"] as const).map((lang) => (
+                  <button
+                    key={lang}
+                    type="button"
+                    onClick={() => {
+                      i18n.changeLanguage(lang);
+                      updateLanguagePreference(lang).catch(() => {});
+                    }}
+                    className={cn(
+                      "px-2.5 py-1 rounded-md text-xs font-semibold uppercase tracking-wide transition-colors",
+                      i18n.language.startsWith(lang)
+                        ? "bg-spanish-teal-100 text-spanish-teal-700"
+                        : "text-slate-400 hover:text-slate-600 hover:bg-slate-100",
+                    )}
+                  >
+                    {lang}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Navigation */}
-          <nav className="flex-1 overflow-y-auto p-4 space-y-1">
-            {navItems.map((item) => {
+          <nav className="flex-1 overflow-y-auto p-4 space-y-1">            {navItems.map((item) => {
               const active = isActive(item.href);
               return (
                 <Link
@@ -240,6 +268,7 @@ export function DashboardLayout({ isAdmin = false }: DashboardLayoutProps) {
               <Menu className="h-6 w-6" />
             </button>
             <div className="flex items-center gap-2">
+              <NotificationBell />
               <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-spanish-teal-500 to-spanish-coral-500 flex items-center justify-center shadow-lg shadow-spanish-teal-500/30">
                 <span className="text-white font-display text-sm font-bold">
                   S

--- a/packages/frontend/src/components/shared/NotificationBell.tsx
+++ b/packages/frontend/src/components/shared/NotificationBell.tsx
@@ -1,0 +1,151 @@
+import { useState, useRef, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { Bell, BellDot, Check, CheckCheck, X } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import { cn } from "@/lib/utils";
+import { useNotifications, type AppNotification } from "@/hooks/useNotifications";
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+export function NotificationBell() {
+  const { notifications, unreadCount, markRead, markAllRead } = useNotifications();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const recent = notifications.slice(0, 10);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="relative p-2 rounded-lg hover:bg-slate-100 text-slate-600 hover:text-slate-900 transition-colors"
+        aria-label={`Notifications ${unreadCount > 0 ? `(${unreadCount} unread)` : ""}`}
+      >
+        {unreadCount > 0 ? (
+          <BellDot className="w-5 h-5 text-spanish-teal-600" />
+        ) : (
+          <Bell className="w-5 h-5" />
+        )}
+        {unreadCount > 0 && (
+          <span className="absolute top-1 right-1 w-4 h-4 bg-red-500 rounded-full text-white text-[10px] font-bold flex items-center justify-center">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, y: -8, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.96 }}
+            transition={{ duration: 0.15 }}
+            className="absolute right-0 top-full mt-2 w-80 bg-white rounded-xl shadow-xl border border-slate-200 z-50 overflow-hidden"
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
+              <span className="text-sm font-semibold text-slate-800">
+                Notifications
+                {unreadCount > 0 && (
+                  <span className="ml-2 text-xs bg-red-100 text-red-600 px-1.5 py-0.5 rounded-full">
+                    {unreadCount}
+                  </span>
+                )}
+              </span>
+              <div className="flex items-center gap-1">
+                {unreadCount > 0 && (
+                  <button
+                    type="button"
+                    onClick={markAllRead}
+                    className="text-xs text-slate-500 hover:text-slate-700 flex items-center gap-1 px-2 py-1 rounded hover:bg-slate-100"
+                  >
+                    <CheckCheck className="w-3 h-3" />
+                    All read
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="p-1 rounded hover:bg-slate-100 text-slate-400"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+
+            {/* List */}
+            <div className="max-h-80 overflow-y-auto">
+              {recent.length === 0 ? (
+                <div className="py-8 text-center text-slate-400 text-sm">
+                  No notifications yet
+                </div>
+              ) : (
+                recent.map((n: AppNotification) => (
+                  <div
+                    key={n.id}
+                    className={cn(
+                      "flex items-start gap-3 px-4 py-3 border-b border-slate-50 last:border-0 hover:bg-slate-50 transition-colors",
+                      !n.readAt && "bg-spanish-teal-50/40",
+                    )}
+                    onClick={() => !n.readAt && markRead(n.id)}
+                  >
+                    <div className="flex-1 min-w-0">
+                      {n.href ? (
+                        <Link
+                          to={n.href}
+                          onClick={() => { !n.readAt && markRead(n.id); setOpen(false); }}
+                          className="block"
+                        >
+                          <p className={cn("text-sm text-slate-800 leading-snug", !n.readAt && "font-semibold")}>
+                            {n.title}
+                          </p>
+                          <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{n.body}</p>
+                        </Link>
+                      ) : (
+                        <>
+                          <p className={cn("text-sm text-slate-800 leading-snug", !n.readAt && "font-semibold")}>
+                            {n.title}
+                          </p>
+                          <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{n.body}</p>
+                        </>
+                      )}
+                      <p className="text-[10px] text-slate-400 mt-1">{timeAgo(n.createdAt)}</p>
+                    </div>
+                    {!n.readAt && (
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); markRead(n.id); }}
+                        className="flex-shrink-0 p-1 rounded hover:bg-slate-200 text-slate-400 mt-0.5"
+                        title="Mark as read"
+                      >
+                        <Check className="w-3.5 h-3.5" />
+                      </button>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/packages/frontend/src/hooks/useNotifications.ts
+++ b/packages/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import api from "@/lib/api";
+
+export interface AppNotification {
+  id: string;
+  type: string;
+  title: string;
+  body: string;
+  href?: string | null;
+  readAt?: string | null;
+  createdAt: string;
+}
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const [connected, setConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+
+  // Load initial notifications from REST
+  useEffect(() => {
+    api
+      .get<{ data: { notifications: AppNotification[] } }>("/notifications")
+      .then((res) => setNotifications(res.data.data.notifications))
+      .catch(() => {});
+  }, []);
+
+  // Open SSE stream
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) return;
+
+    // EventSource doesn't support custom headers; pass token via query param
+    // The backend's authenticate middleware reads cookies or Authorization header.
+    // Since EventSource uses GET with cookies, and we have an httpOnly cookie set
+    // on login, this should work without a token param in same-origin contexts.
+    const es = new EventSource("/api/notifications/stream", { withCredentials: true });
+    esRef.current = es;
+
+    es.addEventListener("connected", () => setConnected(true));
+
+    es.addEventListener("notification", (e: Event) => {
+      try {
+        const notification: AppNotification = JSON.parse((e as MessageEvent).data);
+        setNotifications((prev) => [notification, ...prev].slice(0, 50));
+      } catch {/* ignore parse error */}
+    });
+
+    es.onerror = () => {
+      setConnected(false);
+      // Browser auto-reconnects on error
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, []);
+
+  const unreadCount = notifications.filter((n) => !n.readAt).length;
+
+  const markRead = useCallback(async (id: string) => {
+    await api.put(`/notifications/${id}/read`).catch(() => {});
+    setNotifications((prev) =>
+      prev.map((n) => n.id === id ? { ...n, readAt: new Date().toISOString() } : n),
+    );
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    await api.post("/notifications/read-all").catch(() => {});
+    setNotifications((prev) =>
+      prev.map((n) => ({ ...n, readAt: n.readAt ?? new Date().toISOString() })),
+    );
+  }, []);
+
+  return { notifications, unreadCount, connected, markRead, markAllRead };
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -379,8 +379,10 @@ export const studentApi = {
 
   bookSlot: async (
     slotId: string,
-  ): Promise<{ bookingId: string; slot: AvailabilitySlot }> => {
+  ): Promise<{ bookingId: string; slot: AvailabilitySlot } | { waitlisted: true; data: { position: number; slotId: string } }> => {
     const res = await api.post("/student/bookings", { slotId });
+    // 202 = waitlisted; 201 = booked
+    if (res.data.waitlisted) return res.data;
     return res.data.data;
   },
 

--- a/packages/frontend/src/pages/student/BookPage.tsx
+++ b/packages/frontend/src/pages/student/BookPage.tsx
@@ -114,11 +114,16 @@ export function BookPage() {
 
   const bookMutation = useMutation({
     mutationFn: studentApi.bookSlot,
-    onSuccess: () => {
+    onSuccess: (data: any) => {
       queryClient.invalidateQueries({ queryKey: ["available-slots"] });
       queryClient.invalidateQueries({ queryKey: ["student-dashboard"] });
       queryClient.invalidateQueries({ queryKey: ["student-bookings"] });
-      setBookingSuccess(true);
+      if (data?.waitlisted) {
+        toast.success(`You've been added to the waitlist at position ${data.data?.position ?? 1}. We'll notify you if a spot opens up.`, { duration: 6000 });
+        setSelectedSlot(null);
+      } else {
+        setBookingSuccess(true);
+      }
     },
     onError: (error: any) => {
       toast.error(


### PR DESCRIPTION
…ons (PR-7+8)

--- PR-7: Waitlist for Group Classes ---

New Prisma model WaitlistEntry (waitlist_entries table): slotId, userId, position, notifiedAt. Unique constraint on (slotId, userId). Index on (slotId, position) for fast first-in-line lookup.

booking.ts bookSlot(): before the retry loop, detects FULLY_BOOKED group slots and creates a WaitlistEntry instead of throwing. Returns { waitlisted: true, position: N, slotId } instead of BookSlotResult. Sends sendWaitlistConfirmationToStudent() non-blocking.

booking.ts cancelBooking(): after decrementing currentParticipants, finds the lowest-position WaitlistEntry for that slot, deletes it, resequences remaining positions, and returns promotedWaitlistEntry. Post-transaction: sends sendWaitlistPromotionToStudent() to the promoted student non-blocking.

New emails: sendWaitlistConfirmationToStudent() and sendWaitlistPromotionToStudent() appended to email.ts. HTML email style matches existing templates.

New student endpoints:
  GET    /api/student/slots/:id/waitlist-position
  DELETE /api/student/slots/:id/waitlist

New professor endpoint:
  GET    /api/professor/slots/:id/waitlist

Student booking route: 202 response with { waitlisted: true, data: { position } } instead of 201 when slot is full. Frontend BookPage onSuccess detects waitlisted flag and shows a toast instead of a success screen. studentApi.bookSlot return type extended to union with WaitlistResult.

--- PR-8A: Frontend i18n Language Switcher ---

DashboardLayout sidebar: EN / SR / ES toggle buttons below user info block, visible when sidebar is not collapsed. Calls i18n.changeLanguage() immediately (instant UI switch) + updateLanguagePreference() to persist server-side (non-blocking). Active language highlighted in teal. Imports: i18n from "@/lib/i18n", updateLanguagePreference from "@/lib/api".

--- PR-8B: In-App Notifications (SSE) ---

New Prisma model Notification (notifications table): userId, type, title, body, href?, readAt?, createdAt. Indexed on (userId, readAt) and (userId, createdAt).

New notifications service (src/services/notifications.ts):
  - In-memory fan-out Map<userId, Set<Response>> for SSE connections
  - addSSEConnection / removeSSEConnection for lifecycle management
  - createNotification(userId, type, title, body, href?) — writes to DB
    + pushes SSE event to all active connections for that userId
  - markRead / markAllRead / getNotifications

New notifications router (src/routes/notifications.ts):
  GET  /api/notifications          — list last 30 (unread first)
  PUT  /api/notifications/:id/read
  POST /api/notifications/read-all
  GET  /api/notifications/stream   — SSE: sets text/event-stream headers,
    25-second keepalive pings, auto-removes on client disconnect
Registered in src/index.ts.

booking.ts: createNotification() called at booking creation for both student ("booking_pending") and professor ("booking_request").

Frontend:
  useNotifications hook (src/hooks/useNotifications.ts): fetches initial
    notifications via REST on mount; opens EventSource to /api/notifications/
    stream with credentials; listens for "notification" events; provides
    markRead, markAllRead, unreadCount.
  NotificationBell component (src/components/shared/NotificationBell.tsx):
    Bell icon with red badge (count ≤9 or 9+), animated dropdown showing
    last 10 notifications. Unread notifications have teal background tint.
    Per-notification mark-read button + bulk "All read". Timestamps as
    relative time ("5m ago"). Closes on outside click.
  DashboardLayout: <NotificationBell /> added to mobile sticky header.

Migration: 20260626150000_pr7_pr8_waitlist_notifications — single file creating both waitlist_entries and notifications tables (39 lines).

Generated with Claude Code (https://claude.com/claude-code)