### PR TITLE
feat(security): Zod validation on all remaining backend routes

### DIFF
--- a/packages/backend/src/routes/analytics.ts
+++ b/packages/backend/src/routes/analytics.ts
@@ -1,6 +1,11 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.js";
+import { validateQuery } from "../middleware/validate.js";
 import { AppError } from "../middleware/error.js";
+import {
+  dateRangeQuerySchema,
+  userIdParamSchema,
+} from "@spanish-class/shared";
 import {
   getProfessorAnalytics,
   getStudentEngagementStats,
@@ -15,25 +20,18 @@ router.use(authenticate);
  * GET /api/analytics/professor (T094)
  * Get analytics for the authenticated professor
  */
-router.get("/professor", async (req, res, next) => {
+router.get("/professor", validateQuery(dateRangeQuerySchema), async (req, res, next) => {
   try {
     const professorId = req.user!.id;
+    const { startDate, endDate } = req.query as any;
 
-    // Parse date range from query params
-    const startDate = req.query.startDate
-      ? new Date(req.query.startDate as string)
-      : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // Default: 30 days ago
+    const start = startDate
+      ? new Date(startDate)
+      : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const end = endDate ? new Date(endDate) : new Date();
 
-    const endDate = req.query.endDate
-      ? new Date(req.query.endDate as string)
-      : new Date(); // Default: today
-
-    const analytics = await getProfessorAnalytics(professorId, startDate, endDate);
-
-    res.json({
-      success: true,
-      data: analytics,
-    });
+    const analytics = await getProfessorAnalytics(professorId, start, end);
+    res.json({ success: true, data: analytics });
   } catch (error) {
     next(error);
   }
@@ -45,20 +43,19 @@ router.get("/professor", async (req, res, next) => {
  */
 router.get("/student/:id", async (req, res, next) => {
   try {
-    const { id: studentId } = req.params;
+    const parsed = userIdParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      throw new AppError(400, parsed.error.errors[0].message);
+    }
+    const { id: studentId } = parsed.data;
     const userId = req.user!.id;
 
-    // Only allow users to view their own stats or admins to view any
     if (userId !== studentId && !req.user!.isAdmin) {
       throw new AppError(403, "You can only view your own statistics");
     }
 
     const stats = await getStudentEngagementStats(studentId);
-
-    res.json({
-      success: true,
-      data: stats,
-    });
+    res.json({ success: true, data: stats });
   } catch (error) {
     next(error);
   }
@@ -68,26 +65,20 @@ router.get("/student/:id", async (req, res, next) => {
  * GET /api/analytics/platform (T096)
  * Get platform-wide analytics (admin only)
  */
-router.get("/platform", async (req, res, next) => {
+router.get("/platform", validateQuery(dateRangeQuerySchema), async (req, res, next) => {
   try {
     if (!req.user!.isAdmin) {
       throw new AppError(403, "Only administrators can view platform analytics");
     }
+    const { startDate, endDate } = req.query as any;
 
-    const startDate = req.query.startDate
-      ? new Date(req.query.startDate as string)
+    const start = startDate
+      ? new Date(startDate)
       : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const end = endDate ? new Date(endDate) : new Date();
 
-    const endDate = req.query.endDate
-      ? new Date(req.query.endDate as string)
-      : new Date();
-
-    const analytics = await getPlatformAnalytics(startDate, endDate);
-
-    res.json({
-      success: true,
-      data: analytics,
-    });
+    const analytics = await getPlatformAnalytics(start, end);
+    res.json({ success: true, data: analytics });
   } catch (error) {
     next(error);
   }

--- a/packages/backend/src/routes/availability.ts
+++ b/packages/backend/src/routes/availability.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { authenticate } from "../middleware/auth.js";
 import { prisma } from "../lib/prisma.js";
 import { AppError } from "../middleware/error.js";
+import { slotIdParamSchema } from "@spanish-class/shared";
 
 const router = Router();
 
@@ -11,7 +12,11 @@ const router = Router();
  */
 router.get("/:slotId/participants", authenticate, async (req, res, next) => {
   try {
-    const { slotId } = req.params;
+    const parsed = slotIdParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      throw new AppError(400, parsed.error.errors[0].message);
+    }
+    const { slotId } = parsed.data;
 
     const slot = await prisma.availabilitySlot.findUnique({
       where: { id: slotId },

--- a/packages/backend/src/routes/language.ts
+++ b/packages/backend/src/routes/language.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { detectLanguage, type Locale } from "../middleware/languageDetection.js";
 import { authenticate } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
 import { prisma } from "../lib/prisma.js";
 import { AppError } from "../middleware/error.js";
+import { languagePreferenceSchema } from "@spanish-class/shared";
 
 const router = Router();
 
@@ -12,29 +14,18 @@ const router = Router();
  */
 router.get("/detect", (req, res) => {
   const detection = detectLanguage(req);
-
-  res.json({
-    success: true,
-    data: detection,
-  });
+  res.json({ success: true, data: detection });
 });
 
 /**
  * POST /api/users/language-preference (T066)
  * Update user's language preference
  */
-router.post("/preference", authenticate, async (req, res, next) => {
+router.post("/preference", authenticate, validate(languagePreferenceSchema), async (req, res, next) => {
   try {
     const userId = req.user!.id;
-    const { locale } = req.body;
+    const { locale } = req.body as { locale: Locale };
 
-    // Validate locale
-    const validLocales: Locale[] = ["en", "sr", "es"];
-    if (!validLocales.includes(locale)) {
-      throw new AppError(400, "Invalid locale. Must be one of: en, sr, es");
-    }
-
-    // Update user's language preference
     const user = await prisma.user.update({
       where: { id: userId },
       data: { languagePreference: locale },

--- a/packages/backend/src/routes/notifications.ts
+++ b/packages/backend/src/routes/notifications.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.js";
+import { AppError } from "../middleware/error.js";
+import { notificationIdParamSchema } from "@spanish-class/shared";
 import {
   addSSEConnection,
   removeSSEConnection,
@@ -10,7 +12,6 @@ import {
 
 const router = Router();
 
-// All notification routes require authentication
 router.use(authenticate);
 
 // GET /api/notifications — list last 30 notifications
@@ -26,7 +27,11 @@ router.get("/", async (req, res, next) => {
 // PUT /api/notifications/:id/read — mark one as read
 router.put("/:id/read", async (req, res, next) => {
   try {
-    await markRead(req.params.id, req.user!.id);
+    const parsed = notificationIdParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      throw new AppError(400, parsed.error.errors[0].message);
+    }
+    await markRead(parsed.data.id, req.user!.id);
     res.json({ success: true });
   } catch (error) {
     next(error);
@@ -43,25 +48,23 @@ router.post("/read-all", async (req, res, next) => {
   }
 });
 
-// GET /api/notifications/stream — SSE endpoint
+// GET /api/notifications/stream — SSE endpoint (no body/query to validate)
 router.get("/stream", (req, res) => {
   const userId = req.user!.id;
 
   res.setHeader("Content-Type", "text/event-stream");
   res.setHeader("Cache-Control", "no-cache");
   res.setHeader("Connection", "keep-alive");
-  res.setHeader("X-Accel-Buffering", "no"); // disable nginx buffering
+  res.setHeader("X-Accel-Buffering", "no");
   res.flushHeaders();
 
-  // Send initial "connected" ping
   res.write("event: connected\ndata: {}\n\n");
 
   addSSEConnection(userId, res);
 
-  // Keepalive every 25 seconds to prevent proxy/browser timeout
   const keepalive = setInterval(() => {
     try {
-      res.write(":\n\n"); // SSE comment = keepalive
+      res.write(":\n\n");
     } catch {
       clearInterval(keepalive);
     }

--- a/packages/backend/src/routes/pricing.ts
+++ b/packages/backend/src/routes/pricing.ts
@@ -1,34 +1,32 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
 import { pricingAuth } from "../middleware/pricingAuth.js";
 import {
-  getProfessorPricing,
   getStudentPricing,
   setStudentPricing,
   deleteStudentPricing,
   getProfessorStudents,
 } from "../services/pricing.js";
 import { AppError } from "../middleware/error.js";
+import {
+  createPricingSchema,
+  updatePricingSchema,
+  studentIdParamSchema,
+} from "@spanish-class/shared";
 
 const router = Router();
 
-// All pricing routes require authentication and professor role
 router.use(authenticate);
 router.use(pricingAuth);
 
 /**
  * GET /api/pricing/students (T053)
- * Get all students with their pricing for the authenticated professor
  */
 router.get("/students", async (req, res, next) => {
   try {
-    const professorId = req.user!.id;
-    const students = await getProfessorStudents(professorId);
-
-    res.json({
-      success: true,
-      data: students,
-    });
+    const students = await getProfessorStudents(req.user!.id);
+    res.json({ success: true, data: students });
   } catch (error) {
     next(error);
   }
@@ -36,26 +34,14 @@ router.get("/students", async (req, res, next) => {
 
 /**
  * GET /api/pricing/students/:studentId (T056)
- * Get pricing for a specific student
  */
 router.get("/students/:studentId", async (req, res, next) => {
   try {
-    const professorId = req.user!.id;
-    const { studentId } = req.params;
+    const parsed = studentIdParamSchema.safeParse(req.params);
+    if (!parsed.success) throw new AppError(400, parsed.error.errors[0].message);
 
-    const pricing = await getStudentPricing(professorId, studentId);
-
-    if (!pricing) {
-      return res.json({
-        success: true,
-        data: null,
-      });
-    }
-
-    res.json({
-      success: true,
-      data: pricing,
-    });
+    const pricing = await getStudentPricing(req.user!.id, parsed.data.studentId);
+    res.json({ success: true, data: pricing ?? null });
   } catch (error) {
     next(error);
   }
@@ -63,30 +49,15 @@ router.get("/students/:studentId", async (req, res, next) => {
 
 /**
  * POST /api/pricing/students/:studentId (T054)
- * Create pricing for a student
  */
-router.post("/students/:studentId", async (req, res, next) => {
+router.post("/students/:studentId", validate(createPricingSchema), async (req, res, next) => {
   try {
-    const professorId = req.user!.id;
-    const { studentId } = req.params;
+    const parsed = studentIdParamSchema.safeParse(req.params);
+    if (!parsed.success) throw new AppError(400, parsed.error.errors[0].message);
+
     const { priceRSD, notes } = req.body;
-
-    if (typeof priceRSD !== "number") {
-      throw new AppError(400, "Price must be a number");
-    }
-
-    const pricing = await setStudentPricing(
-      professorId,
-      studentId,
-      priceRSD,
-      notes,
-    );
-
-    res.json({
-      success: true,
-      data: pricing,
-      message: "Pricing created successfully",
-    });
+    const pricing = await setStudentPricing(req.user!.id, parsed.data.studentId, priceRSD, notes);
+    res.json({ success: true, data: pricing, message: "Pricing created successfully" });
   } catch (error) {
     next(error);
   }
@@ -94,30 +65,15 @@ router.post("/students/:studentId", async (req, res, next) => {
 
 /**
  * PUT /api/pricing/students/:studentId (T055)
- * Update pricing for a student
  */
-router.put("/students/:studentId", async (req, res, next) => {
+router.put("/students/:studentId", validate(updatePricingSchema), async (req, res, next) => {
   try {
-    const professorId = req.user!.id;
-    const { studentId } = req.params;
+    const parsed = studentIdParamSchema.safeParse(req.params);
+    if (!parsed.success) throw new AppError(400, parsed.error.errors[0].message);
+
     const { priceRSD, notes } = req.body;
-
-    if (typeof priceRSD !== "number") {
-      throw new AppError(400, "Price must be a number");
-    }
-
-    const pricing = await setStudentPricing(
-      professorId,
-      studentId,
-      priceRSD,
-      notes,
-    );
-
-    res.json({
-      success: true,
-      data: pricing,
-      message: "Pricing updated successfully",
-    });
+    const pricing = await setStudentPricing(req.user!.id, parsed.data.studentId, priceRSD, notes);
+    res.json({ success: true, data: pricing, message: "Pricing updated successfully" });
   } catch (error) {
     next(error);
   }
@@ -125,19 +81,14 @@ router.put("/students/:studentId", async (req, res, next) => {
 
 /**
  * DELETE /api/pricing/students/:studentId
- * Delete pricing for a student
  */
 router.delete("/students/:studentId", async (req, res, next) => {
   try {
-    const professorId = req.user!.id;
-    const { studentId } = req.params;
+    const parsed = studentIdParamSchema.safeParse(req.params);
+    if (!parsed.success) throw new AppError(400, parsed.error.errors[0].message);
 
-    await deleteStudentPricing(professorId, studentId);
-
-    res.json({
-      success: true,
-      message: "Pricing deleted successfully",
-    });
+    await deleteStudentPricing(req.user!.id, parsed.data.studentId);
+    res.json({ success: true, message: "Pricing deleted successfully" });
   } catch (error) {
     next(error);
   }

--- a/packages/backend/src/routes/ratings.ts
+++ b/packages/backend/src/routes/ratings.ts
@@ -1,5 +1,8 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { AppError } from "../middleware/error.js";
+import { createRatingSchema, userIdParamSchema } from "@spanish-class/shared";
 import {
   createRating,
   getUserRatings,
@@ -13,25 +16,13 @@ router.use(authenticate);
 /**
  * POST /api/ratings (T113)
  */
-router.post("/", async (req, res, next) => {
+router.post("/", validate(createRatingSchema), async (req, res, next) => {
   try {
     const raterId = req.user!.id;
     const { rateeId, rating, comment, bookingId, isAnonymous } = req.body;
 
-    const newRating = await createRating(
-      raterId,
-      rateeId,
-      rating,
-      comment,
-      bookingId,
-      isAnonymous,
-    );
-
-    res.json({
-      success: true,
-      data: newRating,
-      message: "Rating submitted successfully",
-    });
+    const newRating = await createRating(raterId, rateeId, rating, comment, bookingId, isAnonymous);
+    res.json({ success: true, data: newRating, message: "Rating submitted successfully" });
   } catch (error) {
     next(error);
   }
@@ -42,13 +33,11 @@ router.post("/", async (req, res, next) => {
  */
 router.get("/user/:id", async (req, res, next) => {
   try {
-    const { id } = req.params;
-    const ratings = await getUserRatings(id);
+    const parsed = userIdParamSchema.safeParse(req.params);
+    if (!parsed.success) throw new AppError(400, parsed.error.errors[0].message);
 
-    res.json({
-      success: true,
-      data: ratings,
-    });
+    const ratings = await getUserRatings(parsed.data.id);
+    res.json({ success: true, data: ratings });
   } catch (error) {
     next(error);
   }
@@ -59,13 +48,8 @@ router.get("/user/:id", async (req, res, next) => {
  */
 router.get("/pending", async (req, res, next) => {
   try {
-    const userId = req.user!.id;
-    const pending = await getPendingRatings(userId);
-
-    res.json({
-      success: true,
-      data: pending,
-    });
+    const pending = await getPendingRatings(req.user!.id);
+    res.json({ success: true, data: pending });
   } catch (error) {
     next(error);
   }

--- a/packages/backend/src/routes/referrals.ts
+++ b/packages/backend/src/routes/referrals.ts
@@ -1,5 +1,7 @@
 import { Router } from "express";
 import { authenticate } from "../middleware/auth.js";
+import { validate } from "../middleware/validate.js";
+import { trackReferralSchema } from "@spanish-class/shared";
 import {
   getUserReferralCode,
   trackReferral,
@@ -15,13 +17,8 @@ router.use(authenticate);
  */
 router.get("/my-code", async (req, res, next) => {
   try {
-    const userId = req.user!.id;
-    const code = await getUserReferralCode(userId);
-
-    res.json({
-      success: true,
-      data: { referralCode: code },
-    });
+    const code = await getUserReferralCode(req.user!.id);
+    res.json({ success: true, data: { referralCode: code } });
   } catch (error) {
     next(error);
   }
@@ -30,18 +27,11 @@ router.get("/my-code", async (req, res, next) => {
 /**
  * POST /api/referrals/track (T108)
  */
-router.post("/track", async (req, res, next) => {
+router.post("/track", validate(trackReferralSchema), async (req, res, next) => {
   try {
     const { referralCode } = req.body;
-    const referredId = req.user!.id;
-
-    const referral = await trackReferral(referralCode, referredId);
-
-    res.json({
-      success: true,
-      data: referral,
-      message: "Referral tracked successfully",
-    });
+    const referral = await trackReferral(referralCode, req.user!.id);
+    res.json({ success: true, data: referral, message: "Referral tracked successfully" });
   } catch (error) {
     next(error);
   }
@@ -52,13 +42,8 @@ router.post("/track", async (req, res, next) => {
  */
 router.get("/stats", async (req, res, next) => {
   try {
-    const userId = req.user!.id;
-    const stats = await getReferralStats(userId);
-
-    res.json({
-      success: true,
-      data: stats,
-    });
+    const stats = await getReferralStats(req.user!.id);
+    res.json({ success: true, data: stats });
   } catch (error) {
     next(error);
   }

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -406,8 +406,6 @@ export const createReferralSchema = z.object({
 
 export type CreateReferralInput = z.infer<typeof createReferralSchema>;
 
-// ── P0 Auth Flows: Password Reset + Email Verification ───────────────────────
-
 export const forgotPasswordSchema = z.object({
   email: z.string().email("Invalid email address"),
 });
@@ -442,3 +440,39 @@ export const resendVerificationSchema = z.object({
 export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
 export type ResetPasswordInput = z.infer<typeof resetPasswordSchema>;
 export type VerifyEmailInput = z.infer<typeof verifyEmailSchema>;
+
+// ── Route-level query / body schemas ─────────────────────────────────────────
+
+// Analytics: date-range query params
+export const dateRangeQuerySchema = z.object({
+  startDate: z.string().datetime({ offset: true }).optional(),
+  endDate:   z.string().datetime({ offset: true }).optional(),
+});
+
+// Language: locale body
+export const languagePreferenceSchema = z.object({
+  locale: z.enum(["en", "sr", "es"]),
+});
+
+// Referrals: track body
+export const trackReferralSchema = z.object({
+  referralCode: z.string().min(1, "Referral code is required").max(50),
+});
+
+// Param schemas — re-usable across routes
+export const notificationIdParamSchema = z.object({
+  id: z.string().min(1, "Notification ID is required"),
+});
+export const slotIdParamSchema = z.object({
+  slotId: z.string().min(1, "Slot ID is required"),
+});
+export const userIdParamSchema = z.object({
+  id: z.string().min(1, "User ID is required"),
+});
+export const studentIdParamSchema = z.object({
+  studentId: z.string().min(1, "Student ID is required"),
+});
+
+export type DateRangeQuery = z.infer<typeof dateRangeQuerySchema>;
+export type LanguagePreferenceInput = z.infer<typeof languagePreferenceSchema>;
+export type TrackReferralInput = z.infer<typeof trackReferralSchema>;


### PR DESCRIPTION
Closes the last gap from the security hardening plan: 7 route files previously had zero input validation, leaving raw req.body/params/query flowing into service functions and Prisma queries unchecked.

Changes per file:

packages/shared/src/schemas.ts
  Added route-level query/body/param schemas:
  - dateRangeQuerySchema (ISO datetime, both optional) — analytics
  - languagePreferenceSchema (enum en|sr|es) — language
  - trackReferralSchema (referralCode string) — referrals
  - notificationIdParamSchema, slotIdParamSchema, userIdParamSchema, studentIdParamSchema — path param guards

packages/backend/src/routes/analytics.ts
  - GET /professor, GET /platform: validateQuery(dateRangeQuerySchema) replaces manual new Date(req.query.x as string) with a validated, typed value; invalid ISO strings now return 400 instead of NaN dates.
  - GET /student/:id: safeParse on params instead of raw req.params.id.

packages/backend/src/routes/availability.ts
  - GET /:slotId/participants: safeParse(slotIdParamSchema) on params.

packages/backend/src/routes/language.ts
  - POST /preference: validate(languagePreferenceSchema) replaces the manual includes() check; Zod returns a typed Locale, the AppError duplicate is removed.

packages/backend/src/routes/notifications.ts
  - PUT /:id/read: safeParse(notificationIdParamSchema) on params so an empty/garbage ID is rejected before hitting the DB.
  - GET / and POST /read-all have no input to validate; SSE stream is likewise input-free. No change needed there.

packages/backend/src/routes/pricing.ts
  - POST/PUT /students/:studentId: validate(create/updatePricingSchema) replaces the manual typeof-number check. Zod enforces integer, non-negative, max 100000 RSD, optional notes with max length.
  - All param-bearing handlers: safeParse(studentIdParamSchema).
  - Removed unused getProfessorPricing import.
  - Removed duplicate route handlers that were left below the old export default (caused TS2528 double-default-export error).

packages/backend/src/routes/ratings.ts
  - POST /: validate(createRatingSchema) — enforces rateeId, rating 1-5 int, optional comment max 1000, optional bookingId/isAnonymous.
  - GET /user/:id: safeParse(userIdParamSchema) on params.

packages/backend/src/routes/referrals.ts
  - POST /track: validate(trackReferralSchema) — referralCode required, max 50 chars. Previously any req.body was passed to trackReferral().

Build: clean (no TS errors). Smoke test: /health 200, login 200.

Generated with Claude Code (https://claude.com/claude-code)