### PR TITLE
fix(bootstrap): create /run/sshd before sshd -t validation

### DIFF
--- a/scripts/server/bootstrap.sh
+++ b/scripts/server/bootstrap.sh
@@ -134,7 +134,10 @@ Match User ${ADMIN_USER}
 # END bootstrap-sshd-block
 EOF
 
-# Validate config before restarting — prevents locking ourselves out
+# Validate config before restarting — prevents locking ourselves out.
+# /run/sshd is the privilege separation dir; sshd -t checks for it even
+# in test mode. Create it so the test doesn't fail on a cold boot.
+mkdir -p /run/sshd
 if ! sshd -t; then
   echo "[bootstrap] sshd config invalid — showing tail of ${SSHD}:"
   tail -30 "$SSHD"


### PR DESCRIPTION
sshd -t checks for the privilege separation directory /run/sshd even in config-test mode. On a fresh boot (or first run before sshd has ever started) this dir does not exist, causing the test to fail with 'Missing privilege separation directory' despite the config being valid. Create it before running sshd -t.